### PR TITLE
Correcting error message when "jdeploy" points to wrong jar

### DIFF
--- a/src/ca/weblite/jdeploy/JDeploy.java
+++ b/src/ca/weblite/jdeploy/JDeploy.java
@@ -414,6 +414,9 @@ public class JDeploy {
     public File findJarFile() {
         if (getJar(null) != null) {
             File jarFile = new File(getJar(null));
+            if (!jarFile.exists() && jarFile.getParentFile() == null) {
+                return null;
+            }
             if (!jarFile.exists() && jarFile.getParentFile().exists()) {
                 // Jar file might be a glob
                 try {
@@ -431,8 +434,6 @@ public class JDeploy {
                 if (!jarFile.exists()) {
                     return null;
                 }
-                
-                
             }
             return jarFile;
         }


### PR DESCRIPTION
When, in package.json, the jar does not exist:
```
...
  "jdeploy": {"jar": "whatever-does-not-exist.jar"},
...
```

```bash
07:47 $ jdeploy publish
Exception in thread "main" java.lang.RuntimeException: java.lang.NullPointerException
	at ca.weblite.jdeploy.JDeploy.main(JDeploy.java:1174)
Caused by: java.lang.NullPointerException
	at ca.weblite.jdeploy.JDeploy.findJarFile(JDeploy.java:417)
	at ca.weblite.jdeploy.JDeploy.copyToBin(JDeploy.java:649)
	at ca.weblite.jdeploy.JDeploy._package(JDeploy.java:1058)
	at ca.weblite.jdeploy.JDeploy.install(JDeploy.java:1063)
	at ca.weblite.jdeploy.JDeploy.publish(JDeploy.java:1084)
	at ca.weblite.jdeploy.JDeploy.main(JDeploy.java:1163)
```