### PR TITLE
Add support for Apple M1 chips

### DIFF
--- a/cli/src/main/resources/ca/weblite/jdeploy/jdeploy.js
+++ b/cli/src/main/resources/ca/weblite/jdeploy/jdeploy.js
@@ -226,6 +226,7 @@ function njreWrap() {
       if (!options.arch) {
         if (/^ppc64|s390x|x32|x64$/g.test(process.arch)) options.arch = process.arch
         else if (process.arch === 'ia32') options.arch = 'x32'
+        else if (process.arch === 'arm64') options.arch = 'aarch64'
         else return Promise.reject(new Error('Unsupported architecture'))
       }
 


### PR DESCRIPTION
Currently `jedploy` returns `Unsupported architecture` when attempting to download a JRE binary on device with an Apple M1 chip. This patch ensures that the darwin aarch64 binary is downloaded when running on a M1 device.