### PR TITLE
fix: Github workflow permissions

### DIFF
--- a/cli/src/main/resources/ca/weblite/jdeploy/github/ant-workflow.yml
+++ b/cli/src/main/resources/ca/weblite/jdeploy/github/ant-workflow.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   build:
-
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK #{{ JAVA_VERSION }}

--- a/cli/src/main/resources/ca/weblite/jdeploy/github/gradle-workflow.yml
+++ b/cli/src/main/resources/ca/weblite/jdeploy/github/gradle-workflow.yml
@@ -13,9 +13,9 @@ permissions:
 
 jobs:
   build:
-
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK #{{ JAVA_VERSION }}

--- a/cli/src/main/resources/ca/weblite/jdeploy/github/maven-workflow.yml
+++ b/cli/src/main/resources/ca/weblite/jdeploy/github/maven-workflow.yml
@@ -10,7 +10,8 @@ on:
 
 jobs:
   build:
-
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Permissions for writing to releases in generated github workflows were not provided which would cause failures. This adds write permissions.