### PR TITLE
added support for permissions

### DIFF
--- a/cli/src/main/java/ca/weblite/jdeploy/gui/JDeployProjectEditor.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/gui/JDeployProjectEditor.java
@@ -9,6 +9,7 @@ import ca.weblite.jdeploy.gui.controllers.VerifyWebsiteController;
 import ca.weblite.jdeploy.gui.services.SwingOneTimePasswordProvider;
 import ca.weblite.jdeploy.gui.tabs.CheerpJSettings;
 import ca.weblite.jdeploy.gui.tabs.DetailsPanel;
+import ca.weblite.jdeploy.gui.tabs.PermissionsPanel;
 import ca.weblite.jdeploy.gui.tabs.PublishSettingsPanel;
 import ca.weblite.jdeploy.helpers.NPMApplicationHelper;
 import ca.weblite.jdeploy.ideInterop.IdeInteropInterface;
@@ -86,6 +87,7 @@ public class JDeployProjectEditor {
     private JMenuItem editGithubWorkflowMenuItem;
     
     private DownloadPageSettingsPanel downloadPageSettingsPanel;
+    private PermissionsPanel permissionsPanel;
 
     private NPM npm = null;
 
@@ -1451,6 +1453,15 @@ public class JDeployProjectEditor {
             tabs.add("CheerpJ", cheerpjSettingsRoot);
         }
         
+        // Permissions panel
+        permissionsPanel = new PermissionsPanel();
+        permissionsPanel.loadPermissions(packageJSON);
+        permissionsPanel.addChangeListener(evt -> {
+            permissionsPanel.savePermissions(packageJSON);
+            setModified();
+        });
+        tabs.add("Permissions", permissionsPanel);
+
         downloadPageSettingsPanel = new DownloadPageSettingsPanel(loadDownloadPageSettings());
         downloadPageSettingsPanel.addChangeListener(evt -> {
             this.saveDownloadPageSettings(downloadPageSettingsPanel.getSettings());

--- a/cli/src/main/java/ca/weblite/jdeploy/gui/tabs/PermissionsPanel.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/gui/tabs/PermissionsPanel.java
@@ -1,0 +1,328 @@
+package ca.weblite.jdeploy.gui.tabs;
+
+import ca.weblite.jdeploy.app.permissions.PermissionRequest;
+import ca.weblite.jdeploy.app.permissions.PermissionRequestService;
+import org.json.JSONObject;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.TitledBorder;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Panel for editing application permissions in the jDeploy project editor.
+ */
+public class PermissionsPanel extends JPanel {
+    
+    private final PermissionRequestService permissionService;
+    private final Map<PermissionRequest, JCheckBox> permissionCheckboxes;
+    private final Map<PermissionRequest, JTextField> descriptionFields;
+    private ActionListener changeListener;
+    
+    public PermissionsPanel() {
+        this.permissionService = new PermissionRequestService();
+        this.permissionCheckboxes = new HashMap<>();
+        this.descriptionFields = new HashMap<>();
+        
+        initializeUI();
+    }
+    
+    private void initializeUI() {
+        setLayout(new BorderLayout());
+        setBorder(new EmptyBorder(10, 10, 10, 10));
+        
+        // Header panel
+        JPanel headerPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        JLabel titleLabel = new JLabel("Application Permissions");
+        titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD, 14f));
+        headerPanel.add(titleLabel);
+        
+        JLabel subtitleLabel = new JLabel(
+            "<html><body style='width: 600px'>" +
+            "Configure the system permissions your application needs. " +
+            "These will be used by platform-specific installers (e.g., macOS Info.plist entries). " +
+            "Permissions not supported by a platform will be ignored." +
+            "</body></html>"
+        );
+        subtitleLabel.setFont(subtitleLabel.getFont().deriveFont(11f));
+        subtitleLabel.setForeground(Color.GRAY);
+        
+        JPanel headerWrapper = new JPanel(new BorderLayout());
+        headerWrapper.add(headerPanel, BorderLayout.NORTH);
+        headerWrapper.add(subtitleLabel, BorderLayout.CENTER);
+        headerWrapper.setBorder(new EmptyBorder(0, 0, 10, 0));
+        
+        add(headerWrapper, BorderLayout.NORTH);
+        
+        // Main content panel with scroll
+        JPanel mainPanel = new JPanel();
+        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
+        
+        createPermissionSections(mainPanel);
+        
+        JScrollPane scrollPane = new JScrollPane(mainPanel);
+        scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+        scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        scrollPane.getVerticalScrollBar().setUnitIncrement(16);
+        
+        add(scrollPane, BorderLayout.CENTER);
+    }
+    
+    private void createPermissionSections(JPanel parent) {
+        // Group permissions by category
+        createPermissionGroup(parent, "Media Access", new PermissionRequest[]{
+            PermissionRequest.CAMERA,
+            PermissionRequest.MICROPHONE,
+            PermissionRequest.PHOTOS,
+            PermissionRequest.PHOTOS_ADD,
+            PermissionRequest.MEDIA_LIBRARY
+        });
+        
+        createPermissionGroup(parent, "Location Services", new PermissionRequest[]{
+            PermissionRequest.LOCATION,
+            PermissionRequest.LOCATION_WHEN_IN_USE,
+            PermissionRequest.LOCATION_ALWAYS
+        });
+        
+        createPermissionGroup(parent, "Personal Data", new PermissionRequest[]{
+            PermissionRequest.CONTACTS,
+            PermissionRequest.CALENDARS,
+            PermissionRequest.CALENDARS_WRITE,
+            PermissionRequest.REMINDERS,
+            PermissionRequest.REMINDERS_WRITE,
+            PermissionRequest.HEALTH_SHARE,
+            PermissionRequest.HEALTH_UPDATE
+        });
+        
+        createPermissionGroup(parent, "System Access", new PermissionRequest[]{
+            PermissionRequest.DESKTOP_FOLDER,
+            PermissionRequest.DOCUMENTS_FOLDER,
+            PermissionRequest.DOWNLOADS_FOLDER,
+            PermissionRequest.NETWORK_VOLUMES,
+            PermissionRequest.REMOVABLE_VOLUMES,
+            PermissionRequest.SYSTEM_ADMINISTRATION,
+            PermissionRequest.APPLE_EVENTS
+        });
+        
+        createPermissionGroup(parent, "Device Features", new PermissionRequest[]{
+            PermissionRequest.BLUETOOTH,
+            PermissionRequest.BLUETOOTH_ALWAYS,
+            PermissionRequest.MOTION,
+            PermissionRequest.FACE_ID,
+            PermissionRequest.SPEECH_RECOGNITION,
+            PermissionRequest.LOCAL_NETWORK
+        });
+        
+        createPermissionGroup(parent, "Services & Privacy", new PermissionRequest[]{
+            PermissionRequest.SIRI,
+            PermissionRequest.HOMEKIT,
+            PermissionRequest.MUSIC,
+            PermissionRequest.TV_PROVIDER,
+            PermissionRequest.VIDEO_SUBSCRIBER,
+            PermissionRequest.FOCUS_STATUS,
+            PermissionRequest.USER_TRACKING,
+            PermissionRequest.FILE_PROVIDER_PRESENCE
+        });
+    }
+    
+    private void createPermissionGroup(JPanel parent, String groupTitle, PermissionRequest[] permissions) {
+        JPanel groupPanel = new JPanel();
+        groupPanel.setLayout(new BoxLayout(groupPanel, BoxLayout.Y_AXIS));
+        groupPanel.setBorder(new TitledBorder(groupTitle));
+        groupPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        
+        for (PermissionRequest permission : permissions) {
+            JPanel permissionPanel = createPermissionRow(permission);
+            groupPanel.add(permissionPanel);
+        }
+        
+        parent.add(groupPanel);
+        parent.add(Box.createVerticalStrut(10));
+    }
+    
+    private JPanel createPermissionRow(PermissionRequest permission) {
+        JPanel rowPanel = new JPanel();
+        rowPanel.setLayout(new BoxLayout(rowPanel, BoxLayout.Y_AXIS));
+        rowPanel.setBorder(new EmptyBorder(5, 10, 5, 10));
+        rowPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        
+        // Top panel with checkbox and macOS key
+        JPanel topPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        topPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        
+        // Checkbox for enabling/disabling permission
+        JCheckBox checkbox = new JCheckBox(getPermissionDisplayName(permission));
+        
+        // macOS key label (for reference)
+        JLabel macOSKeyLabel = new JLabel("(" + permission.getMacOSKey() + ")");
+        macOSKeyLabel.setFont(macOSKeyLabel.getFont().deriveFont(10f));
+        macOSKeyLabel.setForeground(Color.GRAY);
+        
+        topPanel.add(checkbox);
+        topPanel.add(Box.createHorizontalStrut(10));
+        topPanel.add(macOSKeyLabel);
+        
+        // Description field panel (initially hidden)
+        JPanel descPanel = new JPanel(new BorderLayout());
+        descPanel.setBorder(new EmptyBorder(5, 25, 0, 0)); // Left indent to align under checkbox text
+        descPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        
+        JLabel descLabel = new JLabel("Description: ");
+        JTextField descriptionField = new JTextField();
+        descriptionField.getDocument().addDocumentListener(new javax.swing.event.DocumentListener() {
+            public void insertUpdate(javax.swing.event.DocumentEvent e) { fireChangeEvent(); }
+            public void removeUpdate(javax.swing.event.DocumentEvent e) { fireChangeEvent(); }
+            public void changedUpdate(javax.swing.event.DocumentEvent e) { fireChangeEvent(); }
+        });
+        
+        // Set placeholder text
+        String placeholderText = generateGenericDescription(permission);
+        descriptionField.setToolTipText("Leave empty to use default: " + placeholderText);
+        
+        descPanel.add(descLabel, BorderLayout.WEST);
+        descPanel.add(descriptionField, BorderLayout.CENTER);
+        descPanel.setVisible(false); // Initially hidden
+        
+        // Store references
+        permissionCheckboxes.put(permission, checkbox);
+        descriptionFields.put(permission, descriptionField);
+        
+        // Checkbox action listener to show/hide description field
+        checkbox.addActionListener(e -> {
+            boolean enabled = checkbox.isSelected();
+            descPanel.setVisible(enabled);
+            rowPanel.revalidate();
+            rowPanel.repaint();
+            fireChangeEvent();
+        });
+        
+        // Add components to row panel
+        rowPanel.add(topPanel);
+        rowPanel.add(descPanel);
+        
+        return rowPanel;
+    }
+    
+    private String getPermissionDisplayName(PermissionRequest permission) {
+        String name = permission.name().toLowerCase().replace("_", " ");
+        // Capitalize first letter of each word
+        StringBuilder result = new StringBuilder();
+        boolean capitalizeNext = true;
+        for (char c : name.toCharArray()) {
+            if (Character.isWhitespace(c)) {
+                capitalizeNext = true;
+                result.append(c);
+            } else if (capitalizeNext) {
+                result.append(Character.toUpperCase(c));
+                capitalizeNext = false;
+            } else {
+                result.append(c);
+            }
+        }
+        return result.toString();
+    }
+    
+    private String generateGenericDescription(PermissionRequest permission) {
+        String friendlyName = permission.name().toLowerCase().replace("_", " ");
+        return "The " + friendlyName + " permission is required for functionality of this application.";
+    }
+    
+    /**
+     * Loads permissions from the package.json data
+     */
+    public void loadPermissions(JSONObject packageJson) {
+        Map<PermissionRequest, String> permissions = permissionService.getPermissionRequests(packageJson);
+        
+        // Clear all checkboxes and descriptions, hide all description panels
+        permissionCheckboxes.values().forEach(cb -> cb.setSelected(false));
+        descriptionFields.values().forEach(field -> {
+            field.setText("");
+            field.getParent().setVisible(false); // Hide description panel
+        });
+        
+        // Set loaded permissions
+        for (Map.Entry<PermissionRequest, String> entry : permissions.entrySet()) {
+            PermissionRequest permission = entry.getKey();
+            String description = entry.getValue();
+            
+            JCheckBox checkbox = permissionCheckboxes.get(permission);
+            JTextField descField = descriptionFields.get(permission);
+            
+            if (checkbox != null && descField != null) {
+                checkbox.setSelected(true);
+                descField.getParent().setVisible(true); // Show description panel
+                
+                // Only set description if it's not the generic one
+                String genericDesc = generateGenericDescription(permission);
+                if (!genericDesc.equals(description)) {
+                    descField.setText(description);
+                }
+            }
+        }
+        
+        // Refresh the UI
+        revalidate();
+        repaint();
+    }
+    
+    /**
+     * Saves current permissions to the package.json data
+     */
+    public void savePermissions(JSONObject packageJson) {
+        Map<PermissionRequest, String> permissions = new HashMap<>();
+        
+        for (Map.Entry<PermissionRequest, JCheckBox> entry : permissionCheckboxes.entrySet()) {
+            PermissionRequest permission = entry.getKey();
+            JCheckBox checkbox = entry.getValue();
+            
+            if (checkbox.isSelected()) {
+                JTextField descField = descriptionFields.get(permission);
+                String description = descField != null ? descField.getText().trim() : "";
+                
+                // If description is empty, use generic description
+                if (description.isEmpty()) {
+                    description = generateGenericDescription(permission);
+                }
+                
+                permissions.put(permission, description);
+            }
+        }
+        
+        permissionService.savePermissionRequests(packageJson, permissions);
+    }
+    
+    /**
+     * Gets the current permissions as a map
+     */
+    public Map<PermissionRequest, String> getPermissions() {
+        return permissionCheckboxes.entrySet().stream()
+                .filter(entry -> entry.getValue().isSelected())
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> {
+                            JTextField descField = descriptionFields.get(entry.getKey());
+                            String description = descField != null ? descField.getText().trim() : "";
+                            return description.isEmpty() ? 
+                                generateGenericDescription(entry.getKey()) : description;
+                        }
+                ));
+    }
+    
+    /**
+     * Adds a change listener that will be called when permissions are modified
+     */
+    public void addChangeListener(ActionListener listener) {
+        this.changeListener = listener;
+    }
+    
+    private void fireChangeEvent() {
+        if (changeListener != null) {
+            changeListener.actionPerformed(new ActionEvent(this, ActionEvent.ACTION_PERFORMED, "change"));
+        }
+    }
+}

--- a/cli/src/main/java/ca/weblite/jdeploy/packaging/PackageService.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/packaging/PackageService.java
@@ -4,6 +4,8 @@ import ca.weblite.jdeploy.BundleConstants;
 import ca.weblite.jdeploy.JDeploy;
 import ca.weblite.jdeploy.app.AppInfo;
 import ca.weblite.jdeploy.app.JVMSpecification;
+import ca.weblite.jdeploy.app.permissions.PermissionRequest;
+import ca.weblite.jdeploy.app.permissions.PermissionRequestService;
 import ca.weblite.jdeploy.appbundler.Bundler;
 import ca.weblite.jdeploy.appbundler.BundlerCall;
 import ca.weblite.jdeploy.appbundler.BundlerResult;
@@ -57,6 +59,8 @@ public class PackageService implements BundleConstants {
 
     private final PackagingConfig packagingConfig;
 
+    private final PermissionRequestService permissionRequestService;
+
     @Inject
     public PackageService(
             Environment environment,
@@ -66,7 +70,8 @@ public class PackageService implements BundleConstants {
             BundleCodeService bundleCodeService,
             CopyJarRuleBuilder copyJarRuleBuilder,
             ProjectBuilderService projectBuilderService,
-            PackagingConfig packagingConfig
+            PackagingConfig packagingConfig,
+            PermissionRequestService permissionRequestService
     ) {
         this.environment = environment;
         this.jarFinder = jarFinder;
@@ -76,6 +81,7 @@ public class PackageService implements BundleConstants {
         this.copyJarRuleBuilder = copyJarRuleBuilder;
         this.projectBuilderService = projectBuilderService;
         this.packagingConfig = packagingConfig;
+        this.permissionRequestService = permissionRequestService;
     }
 
     public void createJdeployBundle(
@@ -856,6 +862,13 @@ public class PackageService implements BundleConstants {
             appInfo.setAppURL(new File(jarPath).toURL());
         } else {
             throw new IOException("Cannot load app info because find jar file "+jarPath);
+        }
+
+        for (
+                Map.Entry<PermissionRequest, String> permissionRequestEntry
+                : permissionRequestService.getPermissionRequests(context.packageJsonObject()).entrySet()
+        ) {
+            appInfo.addPermissionRequest(permissionRequestEntry.getKey(), permissionRequestEntry.getValue());
         }
 
         File jarFile = new File(jarPath);

--- a/cli/src/main/java/ca/weblite/jdeploy/packaging/PackagingContext.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/packaging/PackagingContext.java
@@ -8,6 +8,7 @@ import ca.weblite.tools.security.KeyProvider;
 import com.codename1.io.JSONParser;
 import com.codename1.processing.Result;
 import org.apache.commons.io.FileUtils;
+import org.json.JSONObject;
 
 import java.io.*;
 import java.util.*;
@@ -133,6 +134,16 @@ public class PackagingContext {
 
     public Map m() {
         return packageJsonMap;
+    }
+
+    /**
+     * Returns the package.json content as a JSONObject for compatibility
+     * with code that expects org.json.JSONObject instead of Map.
+     * 
+     * @return JSONObject representation of the package.json
+     */
+    public JSONObject packageJsonObject() {
+        return new JSONObject(packageJsonMap);
     }
 
     public String getVersion() {

--- a/installer/src/main/java/ca/weblite/jdeploy/installer/Main.java
+++ b/installer/src/main/java/ca/weblite/jdeploy/installer/Main.java
@@ -1,6 +1,7 @@
 package ca.weblite.jdeploy.installer;
 
 import ca.weblite.jdeploy.app.AppInfo;
+import ca.weblite.jdeploy.app.permissions.PermissionRequest;
 import ca.weblite.jdeploy.appbundler.Bundler;
 import ca.weblite.jdeploy.appbundler.BundlerSettings;
 import ca.weblite.jdeploy.helpers.PrereleaseHelper;
@@ -149,6 +150,10 @@ public class Main implements Runnable, Constants {
             }
             for (String scheme : npmPackageVersion().getUrlSchemes()) {
                 appInfo().addUrlScheme(scheme);
+            }
+            
+            for (Map.Entry<PermissionRequest, String> entry : npmPackageVersion().getPermissionRequests().entrySet()) {
+                appInfo().addPermissionRequest(entry.getKey(), entry.getValue());
             }
 
             if (Platform.getSystemPlatform().isWindows() && "8".equals(npmPackageVersion().getJavaVersion())) {

--- a/installer/src/main/java/ca/weblite/jdeploy/installer/npm/NPMPackageVersion.java
+++ b/installer/src/main/java/ca/weblite/jdeploy/installer/npm/NPMPackageVersion.java
@@ -3,10 +3,14 @@ package ca.weblite.jdeploy.installer.npm;
 import ca.weblite.jdeploy.helpers.NPMApplicationHelper;
 import ca.weblite.jdeploy.models.DocumentTypeAssociation;
 import ca.weblite.jdeploy.models.NPMApplication;
+import ca.weblite.jdeploy.app.permissions.PermissionRequest;
+import ca.weblite.jdeploy.app.permissions.PermissionRequestService;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public class NPMPackageVersion {
     private static final String DEFAULT_JAVA_VERSION = "11";
@@ -93,8 +97,7 @@ public class NPMPackageVersion {
         return null;
     }
 
-
-
-
-
+    public Map<PermissionRequest, String> getPermissionRequests() {
+        return new PermissionRequestService().getPermissionRequests(packageJson);
+    }
 }

--- a/shared/src/main/java/ca/weblite/jdeploy/app/AppInfo.java
+++ b/shared/src/main/java/ca/weblite/jdeploy/app/AppInfo.java
@@ -5,6 +5,8 @@
  */
 package ca.weblite.jdeploy.app;
 
+import ca.weblite.jdeploy.app.permissions.PermissionRequest;
+
 import ca.weblite.tools.platform.Platform;
 
 import com.client4j.Client4J;
@@ -61,6 +63,8 @@ public class AppInfo  {
 
     private Set<String> urlSchemes;
 
+    private Map<PermissionRequest, String> permissionRequests;
+
     /**
      * If package signing is enabled,
      */
@@ -99,6 +103,36 @@ public class AppInfo  {
             urlSchemes = new HashSet<>();
         }
         return urlSchemes;
+    }
+
+    public void addPermissionRequest(PermissionRequest request, String description) {
+        if (permissionRequests == null) permissionRequests = new HashMap<>();
+        permissionRequests.put(request, description);
+    }
+
+    public boolean hasPermissionRequests() {
+        return permissionRequests != null && !permissionRequests.isEmpty();
+    }
+
+    public Iterable<PermissionRequest> getPermissionRequests() {
+        if (permissionRequests == null) {
+            return new HashSet<>();
+        }
+        return permissionRequests.keySet();
+    }
+
+    public String getPermissionDescription(PermissionRequest request) {
+        if (permissionRequests != null && permissionRequests.containsKey(request)) {
+            return permissionRequests.get(request);
+        }
+        return null;
+    }
+
+    public Map<PermissionRequest, String> getPermissionRequestsWithDescriptions() {
+        if (permissionRequests == null) {
+            return new HashMap<>();
+        }
+        return new HashMap<>(permissionRequests);
     }
 
     private Map<String, String> documentMimetypes() {
@@ -1337,6 +1371,13 @@ public class AppInfo  {
         out.windowsJdeployHome = windowsJdeployHome;
         out.linuxJdeployHome = linuxJdeployHome;
 
+        if (permissionRequests != null) {
+            out.permissionRequests = new HashMap<>();
+            for (Map.Entry<PermissionRequest, String> entry : permissionRequests.entrySet()) {
+                out.permissionRequests.put(entry.getKey(), entry.getValue());
+            }
+        }
+
         return out;
     }
 
@@ -1439,6 +1480,7 @@ public class AppInfo  {
                 macJdeployHome, o.macJdeployHome,
                 windowsJdeployHome, o.windowsJdeployHome,
                 linuxJdeployHome, o.linuxJdeployHome,
+                permissionRequests, o.permissionRequests,
             
         });
     }

--- a/shared/src/main/java/ca/weblite/jdeploy/app/permissions/PermissionRequest.java
+++ b/shared/src/main/java/ca/weblite/jdeploy/app/permissions/PermissionRequest.java
@@ -1,0 +1,50 @@
+package ca.weblite.jdeploy.app.permissions;
+
+public enum PermissionRequest {
+    CAMERA("NSCameraUsageDescription"),
+    MICROPHONE("NSMicrophoneUsageDescription"),
+    LOCATION("NSLocationUsageDescription"),
+    LOCATION_WHEN_IN_USE("NSLocationWhenInUseUsageDescription"),
+    LOCATION_ALWAYS("NSLocationAlwaysUsageDescription"),
+    CONTACTS("NSContactsUsageDescription"),
+    CALENDARS("NSCalendarsUsageDescription"),
+    REMINDERS("NSRemindersUsageDescription"),
+    PHOTOS("NSPhotoLibraryUsageDescription"),
+    PHOTOS_ADD("NSPhotoLibraryAddUsageDescription"),
+    MOTION("NSMotionUsageDescription"),
+    HEALTH_SHARE("NSHealthShareUsageDescription"),
+    HEALTH_UPDATE("NSHealthUpdateUsageDescription"),
+    BLUETOOTH("NSBluetoothPeripheralUsageDescription"),
+    BLUETOOTH_ALWAYS("NSBluetoothAlwaysUsageDescription"),
+    SPEECH_RECOGNITION("NSSpeechRecognitionUsageDescription"),
+    HOMEKIT("NSHomeKitUsageDescription"),
+    MUSIC("NSAppleMusicUsageDescription"),
+    TV_PROVIDER("NSTVProviderUsageDescription"),
+    VIDEO_SUBSCRIBER("NSVideoSubscriberAccountUsageDescription"),
+    SIRI("NSSiriUsageDescription"),
+    FACE_ID("NSFaceIDUsageDescription"),
+    DESKTOP_FOLDER("NSDesktopFolderUsageDescription"),
+    DOCUMENTS_FOLDER("NSDocumentsFolderUsageDescription"),
+    DOWNLOADS_FOLDER("NSDownloadsFolderUsageDescription"),
+    NETWORK_VOLUMES("NSNetworkVolumesUsageDescription"),
+    REMOVABLE_VOLUMES("NSRemovableVolumesUsageDescription"),
+    FILE_PROVIDER_PRESENCE("NSFileProviderPresenceUsageDescription"),
+    SYSTEM_ADMINISTRATION("NSSystemAdministrationUsageDescription"),
+    APPLE_EVENTS("NSAppleEventsUsageDescription"),
+    LOCAL_NETWORK("NSLocalNetworkUsageDescription"),
+    MEDIA_LIBRARY("NSMediaLibraryUsageDescription"),
+    CALENDARS_WRITE("NSCalendarsWriteUsageDescription"),
+    REMINDERS_WRITE("NSRemindersWriteUsageDescription"),
+    FOCUS_STATUS("NSFocusStatusUsageDescription"),
+    USER_TRACKING("NSUserTrackingUsageDescription");
+
+    private final String macOSKey;
+
+    PermissionRequest(String macOSKey) {
+        this.macOSKey = macOSKey;
+    }
+
+    public String getMacOSKey() {
+        return macOSKey;
+    }
+}

--- a/shared/src/main/java/ca/weblite/jdeploy/app/permissions/PermissionRequestService.java
+++ b/shared/src/main/java/ca/weblite/jdeploy/app/permissions/PermissionRequestService.java
@@ -1,0 +1,79 @@
+package ca.weblite.jdeploy.app.permissions;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Service for loading and processing permission requests from package.json files.
+ */
+public class PermissionRequestService {
+    
+    /**
+     * Parses permission requests from a package.json JSONObject.
+     * 
+     * @param packageJson The package.json content as a JSONObject
+     * @return A map of PermissionRequest to description strings
+     */
+    public Map<PermissionRequest, String> getPermissionRequests(JSONObject packageJson) {
+        Map<PermissionRequest, String> out = new HashMap<>();
+        
+        if (!packageJson.has("jdeploy")) {
+            return out;
+        }
+        
+        JSONObject jdeploy = packageJson.getJSONObject("jdeploy");
+        if (!jdeploy.has("permissions")) {
+            return out;
+        }
+        
+        JSONArray permissions = jdeploy.getJSONArray("permissions");
+        int len = permissions.length();
+        for (int i = 0; i < len; i++) {
+            JSONObject permission = permissions.getJSONObject(i);
+            if (!permission.has("name")) continue;
+            
+            String permissionName = permission.getString("name");
+            PermissionRequest request = getPermissionRequestByName(permissionName);
+            if (request == null) continue;
+            
+            String description;
+            if (permission.has("description")) {
+                description = permission.getString("description");
+            } else {
+                description = generateGenericDescription(permissionName);
+            }
+            
+            out.put(request, description);
+        }
+        
+        return out;
+    }
+    
+    /**
+     * Maps a string permission name to a PermissionRequest enum value.
+     * 
+     * @param name The permission name (case-insensitive)
+     * @return The corresponding PermissionRequest, or null if not found
+     */
+    private static PermissionRequest getPermissionRequestByName(String name) {
+        try {
+            return PermissionRequest.valueOf(name.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+    
+    /**
+     * Generates a generic description for a permission when none is provided.
+     * 
+     * @param permissionName The raw permission name from the JSON
+     * @return A generic description string
+     */
+    private static String generateGenericDescription(String permissionName) {
+        String friendlyName = permissionName.toLowerCase().replace("_", " ");
+        return "The " + friendlyName + " permission is required for functionality of this application.";
+    }
+}

--- a/shared/src/main/java/ca/weblite/jdeploy/app/permissions/PermissionRequestService.java
+++ b/shared/src/main/java/ca/weblite/jdeploy/app/permissions/PermissionRequestService.java
@@ -53,6 +53,49 @@ public class PermissionRequestService {
     }
     
     /**
+     * Saves permission requests to a package.json JSONObject.
+     * 
+     * @param packageJson The package.json JSONObject to modify
+     * @param permissions A map of PermissionRequest to description strings
+     */
+    public void savePermissionRequests(JSONObject packageJson, Map<PermissionRequest, String> permissions) {
+        // Ensure jdeploy section exists
+        if (!packageJson.has("jdeploy")) {
+            packageJson.put("jdeploy", new JSONObject());
+        }
+        
+        JSONObject jdeploy = packageJson.getJSONObject("jdeploy");
+        
+        // If no permissions, remove the permissions array
+        if (permissions == null || permissions.isEmpty()) {
+            jdeploy.remove("permissions");
+            return;
+        }
+        
+        // Create permissions array
+        JSONArray permissionsArray = new JSONArray();
+        
+        for (Map.Entry<PermissionRequest, String> entry : permissions.entrySet()) {
+            JSONObject permission = new JSONObject();
+            String permissionName = entry.getKey().name().toLowerCase();
+            permission.put("name", permissionName);
+            
+            String description = entry.getValue();
+            if (description != null && !description.isEmpty()) {
+                // Only include description if it's not the generic one
+                String genericDescription = generateGenericDescription(permissionName);
+                if (!genericDescription.equals(description)) {
+                    permission.put("description", description);
+                }
+            }
+            
+            permissionsArray.put(permission);
+        }
+        
+        jdeploy.put("permissions", permissionsArray);
+    }
+    
+    /**
      * Maps a string permission name to a PermissionRequest enum value.
      * 
      * @param name The permission name (case-insensitive)

--- a/shared/src/main/java/ca/weblite/jdeploy/appbundler/AppDescription.java
+++ b/shared/src/main/java/ca/weblite/jdeploy/appbundler/AppDescription.java
@@ -50,6 +50,8 @@ public class AppDescription {
     private String jDeployHomeLinux;
     private String jDeployRegistryUrl;
 
+    private Map<String,String> macUsageDescriptions = new HashMap<>();
+
     /**
      * If package signing is enabled, then this flag tells us whether to "pin" the app to the signing certificate.
      * If the app is pinned to a signing certificate, then the launcher will verify the signature of all files
@@ -398,4 +400,11 @@ public class AppDescription {
         return jDeployRegistryUrl;
     }
 
+    public Map<String,String> getMacUsageDescriptions() {
+        return macUsageDescriptions;
+    }
+
+    public void setMacUsageDescription(String key, String value) {
+        macUsageDescriptions.put(key, value);
+    }
 }

--- a/shared/src/main/java/ca/weblite/jdeploy/appbundler/Bundler.java
+++ b/shared/src/main/java/ca/weblite/jdeploy/appbundler/Bundler.java
@@ -10,6 +10,7 @@ import ca.weblite.jdeploy.app.JVMSpecification;
 import ca.weblite.jdeploy.jvmdownloader.JVMKit;
 import ca.weblite.tools.io.URLUtil;
 import ca.weblite.tools.security.CertificateUtil;
+import com.client4j.security.net.PermissionRequest;
 import com.joshondesign.appbundler.linux.LinuxBundler;
 import com.joshondesign.appbundler.mac.MacBundler;
 import com.joshondesign.appbundler.win.WindowsBundler2;
@@ -120,6 +121,14 @@ public class Bundler {
         setupMacCodeSigning(appInfo, app);
         setupFileAssociations(appInfo, app);
         setupUrlSchemes(appInfo, app);
+        setupMacUsageDescriptions(appInfo, app);
+        return app;
+    }
+
+    private static AppDescription setupMacUsageDescriptions(AppInfo appInfo, AppDescription app) {
+        for (ca.weblite.jdeploy.app.permissions.PermissionRequest permissionRequest : appInfo.getPermissionRequests()) {
+            app.setMacUsageDescription(permissionRequest.getMacOSKey(), appInfo.getPermissionDescription(permissionRequest));
+        }
 
         return app;
     }

--- a/shared/src/main/java/com/joshondesign/appbundler/mac/MacBundler.java
+++ b/shared/src/main/java/com/joshondesign/appbundler/mac/MacBundler.java
@@ -525,10 +525,15 @@ public class MacBundler {
                 if(icon != null) {
                     out.start("key").text("CFBundleTypeIconFile").end();
                     File ifile = new File(icon);
-                    System.out.println("doing icon: " + ifile.getAbsolutePath());
                     out.start("string").text(ifile.getName()).end();
                     //copy over the icon
                 }
+
+                for (Map.Entry<String,String> usageDescriptionEntry : app.getMacUsageDescriptions().entrySet()) {
+                    out.start("key").text(usageDescriptionEntry.getKey()).end();
+                    out.start("string").text(usageDescriptionEntry.getValue()).end();
+                }
+
             out.end().end();
         }
 

--- a/shared/src/test/java/ca/weblite/jdeploy/app/permissions/PermissionRequestServiceTest.java
+++ b/shared/src/test/java/ca/weblite/jdeploy/app/permissions/PermissionRequestServiceTest.java
@@ -1,0 +1,349 @@
+package ca.weblite.jdeploy.app.permissions;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PermissionRequestServiceTest {
+
+    private PermissionRequestService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PermissionRequestService();
+    }
+
+    @Test
+    void testGetPermissionRequests_EmptyPackageJson() {
+        JSONObject packageJson = new JSONObject();
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetPermissionRequests_NoJdeploySection() {
+        JSONObject packageJson = new JSONObject();
+        packageJson.put("name", "test-app");
+        packageJson.put("version", "1.0.0");
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetPermissionRequests_EmptyJdeploySection() {
+        JSONObject packageJson = new JSONObject();
+        JSONObject jdeploy = new JSONObject();
+        packageJson.put("jdeploy", jdeploy);
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetPermissionRequests_NoPermissionsArray() {
+        JSONObject packageJson = new JSONObject();
+        JSONObject jdeploy = new JSONObject();
+        jdeploy.put("jar", "app.jar");
+        packageJson.put("jdeploy", jdeploy);
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetPermissionRequests_EmptyPermissionsArray() {
+        JSONObject packageJson = new JSONObject();
+        JSONObject jdeploy = new JSONObject();
+        JSONArray permissions = new JSONArray();
+        jdeploy.put("permissions", permissions);
+        packageJson.put("jdeploy", jdeploy);
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetPermissionRequests_SinglePermissionWithDescription() {
+        JSONObject packageJson = new JSONObject();
+        JSONObject jdeploy = new JSONObject();
+        JSONArray permissions = new JSONArray();
+        
+        JSONObject cameraPermission = new JSONObject();
+        cameraPermission.put("name", "camera");
+        cameraPermission.put("description", "Access camera to scan documents");
+        permissions.put(cameraPermission);
+        
+        jdeploy.put("permissions", permissions);
+        packageJson.put("jdeploy", jdeploy);
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey(PermissionRequest.CAMERA));
+        assertEquals("Access camera to scan documents", result.get(PermissionRequest.CAMERA));
+    }
+
+    @Test
+    void testGetPermissionRequests_SinglePermissionWithoutDescription() {
+        JSONObject packageJson = new JSONObject();
+        JSONObject jdeploy = new JSONObject();
+        JSONArray permissions = new JSONArray();
+        
+        JSONObject microphonePermission = new JSONObject();
+        microphonePermission.put("name", "microphone");
+        permissions.put(microphonePermission);
+        
+        jdeploy.put("permissions", permissions);
+        packageJson.put("jdeploy", jdeploy);
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey(PermissionRequest.MICROPHONE));
+        assertEquals("The microphone permission is required for functionality of this application.", 
+                     result.get(PermissionRequest.MICROPHONE));
+    }
+
+    @Test
+    void testGetPermissionRequests_MultiplePermissions() {
+        JSONObject packageJson = new JSONObject();
+        JSONObject jdeploy = new JSONObject();
+        JSONArray permissions = new JSONArray();
+        
+        JSONObject cameraPermission = new JSONObject();
+        cameraPermission.put("name", "camera");
+        cameraPermission.put("description", "Access camera to scan documents");
+        permissions.put(cameraPermission);
+        
+        JSONObject locationPermission = new JSONObject();
+        locationPermission.put("name", "location_when_in_use");
+        locationPermission.put("description", "Location access for weather features");
+        permissions.put(locationPermission);
+        
+        JSONObject microphonePermission = new JSONObject();
+        microphonePermission.put("name", "microphone");
+        permissions.put(microphonePermission);
+        
+        jdeploy.put("permissions", permissions);
+        packageJson.put("jdeploy", jdeploy);
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertEquals(3, result.size());
+        
+        assertTrue(result.containsKey(PermissionRequest.CAMERA));
+        assertEquals("Access camera to scan documents", result.get(PermissionRequest.CAMERA));
+        
+        assertTrue(result.containsKey(PermissionRequest.LOCATION_WHEN_IN_USE));
+        assertEquals("Location access for weather features", result.get(PermissionRequest.LOCATION_WHEN_IN_USE));
+        
+        assertTrue(result.containsKey(PermissionRequest.MICROPHONE));
+        assertEquals("The microphone permission is required for functionality of this application.", 
+                     result.get(PermissionRequest.MICROPHONE));
+    }
+
+    @Test
+    void testGetPermissionRequests_CaseInsensitivePermissionNames() {
+        JSONObject packageJson = new JSONObject();
+        JSONObject jdeploy = new JSONObject();
+        JSONArray permissions = new JSONArray();
+        
+        JSONObject cameraPermission = new JSONObject();
+        cameraPermission.put("name", "CAMERA");
+        cameraPermission.put("description", "Upper case camera permission");
+        permissions.put(cameraPermission);
+        
+        JSONObject microphonePermission = new JSONObject();
+        microphonePermission.put("name", "Microphone");
+        microphonePermission.put("description", "Mixed case microphone permission");
+        permissions.put(microphonePermission);
+        
+        jdeploy.put("permissions", permissions);
+        packageJson.put("jdeploy", jdeploy);
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertEquals(2, result.size());
+        assertTrue(result.containsKey(PermissionRequest.CAMERA));
+        assertTrue(result.containsKey(PermissionRequest.MICROPHONE));
+        assertEquals("Upper case camera permission", result.get(PermissionRequest.CAMERA));
+        assertEquals("Mixed case microphone permission", result.get(PermissionRequest.MICROPHONE));
+    }
+
+    @Test
+    void testGetPermissionRequests_InvalidPermissionName() {
+        JSONObject packageJson = new JSONObject();
+        JSONObject jdeploy = new JSONObject();
+        JSONArray permissions = new JSONArray();
+        
+        JSONObject invalidPermission = new JSONObject();
+        invalidPermission.put("name", "invalid_permission");
+        invalidPermission.put("description", "This should be ignored");
+        permissions.put(invalidPermission);
+        
+        JSONObject validPermission = new JSONObject();
+        validPermission.put("name", "camera");
+        validPermission.put("description", "Valid camera permission");
+        permissions.put(validPermission);
+        
+        jdeploy.put("permissions", permissions);
+        packageJson.put("jdeploy", jdeploy);
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey(PermissionRequest.CAMERA));
+        assertEquals("Valid camera permission", result.get(PermissionRequest.CAMERA));
+    }
+
+    @Test
+    void testGetPermissionRequests_PermissionMissingName() {
+        JSONObject packageJson = new JSONObject();
+        JSONObject jdeploy = new JSONObject();
+        JSONArray permissions = new JSONArray();
+        
+        JSONObject missingNamePermission = new JSONObject();
+        missingNamePermission.put("description", "Permission without name should be ignored");
+        permissions.put(missingNamePermission);
+        
+        JSONObject validPermission = new JSONObject();
+        validPermission.put("name", "camera");
+        validPermission.put("description", "Valid camera permission");
+        permissions.put(validPermission);
+        
+        jdeploy.put("permissions", permissions);
+        packageJson.put("jdeploy", jdeploy);
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey(PermissionRequest.CAMERA));
+        assertEquals("Valid camera permission", result.get(PermissionRequest.CAMERA));
+    }
+
+    @Test
+    void testGetPermissionRequests_ComplexUnderscorePermissions() {
+        JSONObject packageJson = new JSONObject();
+        JSONObject jdeploy = new JSONObject();
+        JSONArray permissions = new JSONArray();
+        
+        JSONObject locationAlways = new JSONObject();
+        locationAlways.put("name", "location_always");
+        permissions.put(locationAlways);
+        
+        JSONObject photosAdd = new JSONObject();
+        photosAdd.put("name", "photos_add");
+        permissions.put(photosAdd);
+        
+        JSONObject userTracking = new JSONObject();
+        userTracking.put("name", "user_tracking");
+        userTracking.put("description", "Track user behavior for analytics");
+        permissions.put(userTracking);
+        
+        jdeploy.put("permissions", permissions);
+        packageJson.put("jdeploy", jdeploy);
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertEquals(3, result.size());
+        
+        assertTrue(result.containsKey(PermissionRequest.LOCATION_ALWAYS));
+        assertEquals("The location always permission is required for functionality of this application.", 
+                     result.get(PermissionRequest.LOCATION_ALWAYS));
+        
+        assertTrue(result.containsKey(PermissionRequest.PHOTOS_ADD));
+        assertEquals("The photos add permission is required for functionality of this application.", 
+                     result.get(PermissionRequest.PHOTOS_ADD));
+        
+        assertTrue(result.containsKey(PermissionRequest.USER_TRACKING));
+        assertEquals("Track user behavior for analytics", result.get(PermissionRequest.USER_TRACKING));
+    }
+
+    @Test
+    void testGetPermissionRequests_EmptyDescription() {
+        JSONObject packageJson = new JSONObject();
+        JSONObject jdeploy = new JSONObject();
+        JSONArray permissions = new JSONArray();
+        
+        JSONObject cameraPermission = new JSONObject();
+        cameraPermission.put("name", "camera");
+        cameraPermission.put("description", "");
+        permissions.put(cameraPermission);
+        
+        jdeploy.put("permissions", permissions);
+        packageJson.put("jdeploy", jdeploy);
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey(PermissionRequest.CAMERA));
+        assertEquals("", result.get(PermissionRequest.CAMERA));
+    }
+
+    @Test
+    void testGetPermissionRequests_NullDescription() {
+        JSONObject packageJson = new JSONObject();
+        JSONObject jdeploy = new JSONObject();
+        JSONArray permissions = new JSONArray();
+        
+        JSONObject cameraPermission = new JSONObject();
+        cameraPermission.put("name", "camera");
+        cameraPermission.put("description", (String) null);
+        permissions.put(cameraPermission);
+        
+        jdeploy.put("permissions", permissions);
+        packageJson.put("jdeploy", jdeploy);
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey(PermissionRequest.CAMERA));
+        assertEquals("The camera permission is required for functionality of this application.", 
+                     result.get(PermissionRequest.CAMERA));
+    }
+
+    @Test
+    void testGetPermissionRequests_AllMacOSPermissions() {
+        JSONObject packageJson = new JSONObject();
+        JSONObject jdeploy = new JSONObject();
+        JSONArray permissions = new JSONArray();
+        
+        // Test a few key permissions to verify they all work
+        String[] permissionNames = {
+            "camera", "microphone", "location", "contacts", "calendars",
+            "photos", "bluetooth", "siri", "face_id", "desktop_folder"
+        };
+        
+        for (String permissionName : permissionNames) {
+            JSONObject permission = new JSONObject();
+            permission.put("name", permissionName);
+            permission.put("description", "Test description for " + permissionName);
+            permissions.put(permission);
+        }
+        
+        jdeploy.put("permissions", permissions);
+        packageJson.put("jdeploy", jdeploy);
+        
+        Map<PermissionRequest, String> result = service.getPermissionRequests(packageJson);
+        
+        assertEquals(permissionNames.length, result.size());
+        
+        for (String permissionName : permissionNames) {
+            PermissionRequest expectedEnum = PermissionRequest.valueOf(permissionName.toUpperCase());
+            assertTrue(result.containsKey(expectedEnum));
+            assertEquals("Test description for " + permissionName, result.get(expectedEnum));
+        }
+    }
+}


### PR DESCRIPTION
Defined in jdeploy.permissions object as array of objects with name and description keys. Manifested as Info.plist XXXUsageDescription keys in MacOS bundles.

Part of addressing https://github.com/shannah/jdeploy/issues/225