### PR TITLE
fix: Placeholder linux icon in the taskbar

### DIFF
--- a/installer/src/main/java/ca/weblite/jdeploy/installer/Main.java
+++ b/installer/src/main/java/ca/weblite/jdeploy/installer/Main.java
@@ -804,6 +804,15 @@ public class Main implements Runnable, Constants {
     }
 
     private void writeLinuxDesktopFile(File dest, String appTitle, File appIcon, File launcher) throws IOException {
+        // Derive StartupWMClass from the npm package name
+        String wmClass = npmPackageVersion().getMainClass();
+        if (wmClass != null) {
+            wmClass = wmClass.replaceAll("\\.", "-");
+        }
+        if (npmPackageVersion().getWmClassName() != null) {
+            wmClass = npmPackageVersion().getWmClassName();
+        }
+
         String contents = "[Desktop Entry]\n" +
                 "Version=1.0\n" +
                 "Type=Application\n" +
@@ -812,6 +821,11 @@ public class Main implements Runnable, Constants {
                 "Exec=\"{{LAUNCHER_PATH}}\" %U\n" +
                 "Comment=Launch {{APP_TITLE}}\n" +
                 "Terminal=false\n";
+
+        // Add StartupWMClass if we have a valid value
+        if (wmClass != null && !wmClass.isEmpty()) {
+            contents += "StartupWMClass=" + wmClass + "\n";
+        }
 
         if (appInfo().hasDocumentTypes() || appInfo().hasUrlSchemes()) {
             StringBuilder mimetypes = new StringBuilder();

--- a/installer/src/main/java/ca/weblite/jdeploy/installer/npm/NPMPackage.java
+++ b/installer/src/main/java/ca/weblite/jdeploy/installer/npm/NPMPackage.java
@@ -18,8 +18,6 @@ public class NPMPackage {
         return packageInfo.getString("name");
     }
 
-
-
     private static boolean isPrerelease(String version) {
         if (!version.contains("-")) return false;
         String lcVersion = version.toLowerCase();
@@ -135,7 +133,4 @@ public class NPMPackage {
         }
         return new NPMPackageVersion(this, versionNumber, packageInfo.getJSONObject("versions").getJSONObject(versionNumber));
     }
-
-
-
 }

--- a/installer/src/main/java/ca/weblite/jdeploy/installer/npm/NPMPackageVersion.java
+++ b/installer/src/main/java/ca/weblite/jdeploy/installer/npm/NPMPackageVersion.java
@@ -100,4 +100,18 @@ public class NPMPackageVersion {
     public Map<PermissionRequest, String> getPermissionRequests() {
         return new PermissionRequestService().getPermissionRequests(packageJson);
     }
+
+    public String getMainClass() {
+        if (jdeploy().has("mainClass")) {
+            return jdeploy().getString("mainClass");
+        }
+        return null;
+    }
+
+    public String getWmClassName() {
+        if (jdeploy().has("linux") && jdeploy().getJSONObject("linux").has("wmClassName")) {
+            return jdeploy().getJSONObject("linux").getString("wmClassName");
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
This will publish the main class in the package.json file, which is used by the linux installer to set the StartupWMClass property of the desktop file on linux. This is used to set the icon on the status bar, as reported in https://github.com/shannah/jdeploy/issues/273