### PR TITLE
refactor: Install Claude Code skill instead of modifying CLAUDE.md

### DIFF
--- a/cli/src/main/java/ca/weblite/jdeploy/gui/JDeployProjectEditor.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/gui/JDeployProjectEditor.java
@@ -760,8 +760,8 @@ public class JDeployProjectEditor {
                     get();
                     JOptionPane.showMessageDialog(
                         frame,
-                        "Claude AI assistant has been successfully set up for this project.\nCLAUDE.md file has been created/updated with jDeploy-specific instructions.",
-                        "Claude Setup Complete",
+                        "Claude Code jDeploy skill has been installed for this project.\nThe skill is located at .claude/skills/setup-jdeploy.md",
+                        "Claude Skill Installed",
                         JOptionPane.INFORMATION_MESSAGE
                     );
                 } catch (Exception ex) {

--- a/cli/src/main/java/ca/weblite/jdeploy/gui/MenuBarBuilder.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/gui/MenuBarBuilder.java
@@ -147,9 +147,9 @@ public class MenuBarBuilder {
         );
         verifyHomepage.addActionListener(evt -> callbacks.onVerifyHomepage());
 
-        JMenuItem setupClaude = new JMenuItem("Setup Claude AI Assistant");
+        JMenuItem setupClaude = new JMenuItem("Install Claude Code jDeploy Skill");
         setupClaude.setToolTipText(
-                "Setup Claude AI assistant for this project by adding jDeploy-specific instructions to CLAUDE.md"
+                "Install the jDeploy setup skill for Claude Code at .claude/skills/setup-jdeploy.md"
         );
         setupClaude.addActionListener(evt -> callbacks.onSetupClaude());
 

--- a/cli/src/test/java/ca/weblite/jdeploy/claude/SetupClaudeServiceTest.java
+++ b/cli/src/test/java/ca/weblite/jdeploy/claude/SetupClaudeServiceTest.java
@@ -13,76 +13,80 @@ import static org.junit.jupiter.api.Assertions.*;
 class SetupClaudeServiceTest {
 
     @Test
-    void testSetup_createNewClaudeFile(@TempDir File tempDir) throws IOException {
+    void testSetup_createsSkillFile(@TempDir File tempDir) throws IOException {
         SetupClaudeService service = new SetupClaudeService();
-        
+
         service.setup(tempDir);
-        
-        File claudeFile = new File(tempDir, "CLAUDE.md");
-        assertTrue(claudeFile.exists(), "CLAUDE.md file should be created");
-        
-        String content = FileUtils.readFileToString(claudeFile, StandardCharsets.UTF_8);
-        assertFalse(content.isEmpty(), "CLAUDE.md content should not be empty");
+
+        File skillFile = new File(tempDir, ".claude/skills/setup-jdeploy.md");
+        assertTrue(skillFile.exists(), "Skill file should be created at .claude/skills/setup-jdeploy.md");
+
+        String content = FileUtils.readFileToString(skillFile, StandardCharsets.UTF_8);
+        assertFalse(content.isEmpty(), "Skill content should not be empty");
         assertTrue(content.contains("jDeploy"), "Content should contain jDeploy information");
     }
 
     @Test
-    void testSetup_appendToExistingClaudeFile(@TempDir File tempDir) throws IOException {
+    void testSetup_createsSkillsDirectory(@TempDir File tempDir) throws IOException {
         SetupClaudeService service = new SetupClaudeService();
-        
-        File claudeFile = new File(tempDir, "CLAUDE.md");
-        String existingContent = "# My Project\n\nThis is my existing project documentation.\n";
-        FileUtils.writeStringToFile(claudeFile, existingContent, StandardCharsets.UTF_8);
-        
+
+        File skillsDir = new File(tempDir, ".claude/skills");
+        assertFalse(skillsDir.exists(), "Skills directory should not exist before setup");
+
         service.setup(tempDir);
-        
-        String finalContent = FileUtils.readFileToString(claudeFile, StandardCharsets.UTF_8);
-        assertTrue(finalContent.startsWith(existingContent), "Original content should be preserved");
-        assertTrue(finalContent.contains("jDeploy"), "New content should be appended");
-        assertTrue(finalContent.length() > existingContent.length(), "File should be longer after appending");
+
+        assertTrue(skillsDir.exists(), "Skills directory should be created");
+        assertTrue(skillsDir.isDirectory(), "Skills should be a directory");
     }
 
     @Test
-    void testSetup_noDuplicateContent(@TempDir File tempDir) throws IOException {
+    void testSetup_overwritesExistingSkillFile(@TempDir File tempDir) throws IOException {
         SetupClaudeService service = new SetupClaudeService();
-        
+
+        File skillsDir = new File(tempDir, ".claude/skills");
+        skillsDir.mkdirs();
+        File skillFile = new File(skillsDir, "setup-jdeploy.md");
+        String oldContent = "# Old content\n\nThis is old content.";
+        FileUtils.writeStringToFile(skillFile, oldContent, StandardCharsets.UTF_8);
+
         service.setup(tempDir);
-        
-        File claudeFile = new File(tempDir, "CLAUDE.md");
-        String firstContent = FileUtils.readFileToString(claudeFile, StandardCharsets.UTF_8);
-        
-        service.setup(tempDir);
-        
-        String secondContent = FileUtils.readFileToString(claudeFile, StandardCharsets.UTF_8);
-        assertEquals(firstContent, secondContent, "Content should not be duplicated on subsequent runs");
+
+        String newContent = FileUtils.readFileToString(skillFile, StandardCharsets.UTF_8);
+        assertNotEquals(oldContent, newContent, "Skill file should be overwritten with new content");
+        assertTrue(newContent.contains("jDeploy"), "New content should contain jDeploy information");
     }
 
     @Test
-    void testSetup_existingJDeploySection(@TempDir File tempDir) throws IOException {
+    void testIsInstalled_returnsTrueWhenSkillExists(@TempDir File tempDir) throws IOException {
         SetupClaudeService service = new SetupClaudeService();
-        
-        File claudeFile = new File(tempDir, "CLAUDE.md");
-        String existingContent = "# My Project\n\nThis is my project.\n\n# Claude Instructions for jDeploy Setup\n\nThis project is already configured for jDeploy.\n";
-        FileUtils.writeStringToFile(claudeFile, existingContent, StandardCharsets.UTF_8);
-        
+
+        assertFalse(service.isInstalled(tempDir), "Should return false before setup");
+
         service.setup(tempDir);
-        
-        String finalContent = FileUtils.readFileToString(claudeFile, StandardCharsets.UTF_8);
-        assertEquals(existingContent, finalContent, "Content should not be modified when jDeploy section already exists");
+
+        assertTrue(service.isInstalled(tempDir), "Should return true after setup");
+    }
+
+    @Test
+    void testIsInstalled_returnsFalseForInvalidDirectory() {
+        SetupClaudeService service = new SetupClaudeService();
+
+        assertFalse(service.isInstalled(null), "Should return false for null directory");
+        assertFalse(service.isInstalled(new File("/non/existent/directory")), "Should return false for non-existent directory");
     }
 
     @Test
     void testSetup_invalidProjectDirectory() {
         SetupClaudeService service = new SetupClaudeService();
-        
+
         assertThrows(IllegalArgumentException.class, () -> {
             service.setup(null);
         }, "Should throw exception for null directory");
-        
+
         assertThrows(IllegalArgumentException.class, () -> {
             service.setup(new File("/non/existent/directory"));
         }, "Should throw exception for non-existent directory");
-        
+
         File tempFile;
         try {
             tempFile = File.createTempFile("test", ".txt");
@@ -90,7 +94,7 @@ class SetupClaudeServiceTest {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        
+
         assertThrows(IllegalArgumentException.class, () -> {
             service.setup(tempFile);
         }, "Should throw exception for file instead of directory");
@@ -99,7 +103,7 @@ class SetupClaudeServiceTest {
     @Test
     void testSetup_networkFailureHandling(@TempDir File tempDir) {
         SetupClaudeService service = new SetupClaudeService();
-        
+
         assertDoesNotThrow(() -> {
             service.setup(tempDir);
         }, "Service should handle network issues gracefully");

--- a/cli/src/test/java/ca/weblite/jdeploy/gui/MenuBarBuilderTest.java
+++ b/cli/src/test/java/ca/weblite/jdeploy/gui/MenuBarBuilderTest.java
@@ -154,8 +154,8 @@ public class MenuBarBuilderTest {
         JMenuBar menuBar = builder.build();
         JMenu fileMenu = findMenuByName(menuBar, "File");
         assertNotNull(fileMenu, "File menu should exist");
-        assertNotNull(findMenuItemByText(fileMenu, "Setup Claude AI Assistant"), 
-                "Setup Claude AI Assistant item should exist in File menu");
+        assertNotNull(findMenuItemByText(fileMenu, "Install Claude Code jDeploy Skill"),
+                "Install Claude Code jDeploy Skill item should exist in File menu");
     }
 
     @Test


### PR DESCRIPTION
Changed SetupClaudeService to install jDeploy instructions as a Claude Code skill at .claude/skills/setup-jdeploy.md instead of appending to CLAUDE.md. This is less intrusive and follows best practices for Claude Code skills.