### PR TITLE
feat: Add conditional CLI installation snippets to GitHub release notes

### DIFF
--- a/cli/src/main/java/ca/weblite/jdeploy/helpers/GithubReleaseNotesMutator.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/helpers/GithubReleaseNotesMutator.java
@@ -48,6 +48,16 @@ public class GithubReleaseNotesMutator implements BundleConstants {
             final String branchTag,
             final String refType
     ) {
+        return createGithubReleaseNotes(repo, branchTag, refType, false, null);
+    }
+
+    public String createGithubReleaseNotes(
+            final String repo,
+            final String branchTag,
+            final String refType,
+            final boolean hasCommands,
+            final String version
+    ) {
         final String releasesPrefix = "/releases/download/";
         final File releaseFilesDir = getGithubReleaseFilesDir();
         final Optional<File> macIntelBundle = Arrays.stream(
@@ -114,19 +124,61 @@ public class GithubReleaseNotesMutator implements BundleConstants {
                 .append("<!-- id:").append(BUNDLE_LINUX_ARM64).append("-link -->")
                 .append("\n"));
 
-        if ("branch".equals(refType)) {
-            notes.append("\nOr launch app installer via command-line on Linux, Mac, or Windows:\n\n");
-            notes.append("```bash\n");
-            notes.append("/bin/bash -c \"$(curl -fsSL ").append(JDEPLOY_WEBSITE_URL).append("gh/")
-                    .append(repo).append("/").append(branchTag).append("/install.sh)\"\n");
-            notes.append("```\n");
-            notes.append("\nSee [download page](").append(JDEPLOY_WEBSITE_URL).append("gh/").append(repo).append("/").append(branchTag).append(") for more download options.\n\n");
-        } else {
-            notes.append("\nOr launch app installer via command-line on Linux, Mac, or Windows:\n\n");
-            notes.append("```bash\n");
-            notes.append("/bin/bash -c \"$(curl -fsSL ").append(JDEPLOY_WEBSITE_URL).append("gh/").append(repo).append("/install.sh)\"\n");
-            notes.append("```\n");
-            notes.append("\nSee [download page](").append(JDEPLOY_WEBSITE_URL).append("gh/").append(repo).append(") for more download options.\n\n");
+        // Only show CLI installation section if the app has commands defined
+        if (hasCommands) {
+            notes.append("\n## CLI Installation\n\n");
+
+            if ("branch".equals(refType)) {
+                // Branch release - include branch in URL
+                String baseUrl = JDEPLOY_WEBSITE_URL + "gh/" + repo + "/" + branchTag;
+
+                notes.append("### Interactive\n");
+                notes.append("```bash\n");
+                notes.append("/bin/bash -c \"$(curl -fsSL '").append(baseUrl).append("/install.sh')\"\n");
+                notes.append("```\n");
+                notes.append("Launches graphical installer\n\n");
+
+                notes.append("### Headless\n");
+                notes.append("```bash\n");
+                notes.append("/bin/bash -c \"$(curl -fsSL '").append(baseUrl).append("/install.sh?headless=true')\"\n");
+                notes.append("```\n");
+                notes.append("For CI/CD and automated deployments\n\n");
+
+                if (version != null && !version.isEmpty()) {
+                    notes.append("### Version-Pinned Headless\n");
+                    notes.append("```bash\n");
+                    notes.append("/bin/bash -c \"$(curl -fsSL '").append(baseUrl).append("/").append(version).append("/install.sh?headless=true')\"\n");
+                    notes.append("```\n");
+                    notes.append("Install specific version ").append(version).append("\n\n");
+                }
+
+                notes.append("See [download page](").append(baseUrl).append(") for more download options.\n\n");
+            } else {
+                // Tag release - no branch in URL
+                String baseUrl = JDEPLOY_WEBSITE_URL + "gh/" + repo;
+
+                notes.append("### Interactive\n");
+                notes.append("```bash\n");
+                notes.append("/bin/bash -c \"$(curl -fsSL '").append(baseUrl).append("/install.sh')\"\n");
+                notes.append("```\n");
+                notes.append("Launches graphical installer\n\n");
+
+                notes.append("### Headless\n");
+                notes.append("```bash\n");
+                notes.append("/bin/bash -c \"$(curl -fsSL '").append(baseUrl).append("/install.sh?headless=true')\"\n");
+                notes.append("```\n");
+                notes.append("For CI/CD and automated deployments\n\n");
+
+                if (version != null && !version.isEmpty()) {
+                    notes.append("### Version-Pinned Headless\n");
+                    notes.append("```bash\n");
+                    notes.append("/bin/bash -c \"$(curl -fsSL '").append(baseUrl).append("/").append(version).append("/install.sh?headless=true')\"\n");
+                    notes.append("```\n");
+                    notes.append("Install specific version ").append(version).append("\n\n");
+                }
+
+                notes.append("See [download page](").append(baseUrl).append(") for more download options.\n\n");
+            }
         }
 
         return notes.toString();

--- a/cli/src/main/java/ca/weblite/jdeploy/publishing/github/GitHubPublishDriver.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/publishing/github/GitHubPublishDriver.java
@@ -368,10 +368,24 @@ public class GitHubPublishDriver implements PublishDriverInterface {
 
 
     private String createGithubReleaseNotes(PublishingContext context, PublishTargetInterface target) {
+        // Check if the app has CLI commands defined
+        boolean hasCommands = false;
+        try {
+            JDeployProject project = projectFactory.createProject(context.packagingContext.packageJsonFile.toPath());
+            hasCommands = !project.getCommandSpecs().isEmpty();
+        } catch (Exception e) {
+            // If we can't load the project, assume no commands
+            context.err().println("Warning: Could not check for CLI commands: " + e.getMessage());
+        }
+
+        String version = context.packagingContext.getVersion();
+
         return new GithubReleaseNotesMutator(context.directory(), context.err()).createGithubReleaseNotes(
                 getRepository(context, target),
                 getRefName(context, target),
-                getRefType(context, target)
+                getRefType(context, target),
+                hasCommands,
+                version
         );
     }
 


### PR DESCRIPTION
Show 3 CLI installation variants (Interactive, Headless, Version-Pinned Headless) in GitHub release descriptions only when the app has commands defined in jdeploy.commands. Apps without commands no longer show CLI installation instructions.