### PR TITLE
fix: avoid "null" in template substitution when githubRepository is not set

### DIFF
--- a/cli/src/main/java/ca/weblite/jdeploy/services/ProjectGenerator.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/services/ProjectGenerator.java
@@ -130,9 +130,9 @@ public class ProjectGenerator {
         buildFileSource = buildFileSource.replace("{{ packageName }}", request.getPackageName());
         buildFileSource = buildFileSource.replace("{{ packagePath }}", request.getPackageName().replace(".", "/"));
         buildFileSource = buildFileSource.replace("{{ javaVersion }}", String.valueOf(getJavaVersion()));
-        buildFileSource = buildFileSource.replace("{{ githubRepository }}", String.valueOf(request.getGithubRepository()));
-        buildFileSource = buildFileSource.replace("{{ githubReleasesRepository }}", getReleasesRepository(request));
-        buildFileSource = buildFileSource.replace("{{ releasesUrl }}", getReleasesUrl(request));
+        buildFileSource = buildFileSource.replace("{{ githubRepository }}", request.getGithubRepository() != null ? request.getGithubRepository() : "");
+        buildFileSource = buildFileSource.replace("{{ githubReleasesRepository }}", request.getGithubRepository() != null ? getReleasesRepository(request) : "");
+        buildFileSource = buildFileSource.replace("{{ releasesUrl }}", request.getGithubRepository() != null ? getReleasesUrl(request) : "");
         return buildFileSource;
     }
 


### PR DESCRIPTION
## Summary
- When `ProjectGenerator.generate()` is called without a `githubRepository` (e.g. from the MCP server), the template tokens `{{ githubRepository }}`, `{{ githubReleasesRepository }}`, and `{{ releasesUrl }}` were replaced with the literal string `"null"` (`String.valueOf(null)` returns `"null"`). This left broken values in generated build files and properties.
- Now uses empty string instead when `githubRepository` is not provided.

## Test plan
- [ ] Generate a project without specifying `githubRepository` and verify no `"null"` strings appear in generated files
- [ ] Generate a project with `githubRepository` set and verify substitution still works correctly