### PR TITLE
fix: output JRE download message to stderr for MCP server compatibility

### DIFF
--- a/cli/src/main/resources/ca/weblite/jdeploy/jdeploy.js
+++ b/cli/src/main/resources/ca/weblite/jdeploy/jdeploy.js
@@ -539,7 +539,7 @@ if (!done) {
 }
 
 if (!done) {
-    console.log("Downloading java runtime environment for version "+targetJavaVersion);
+    console.error("Downloading java runtime environment for version "+targetJavaVersion);
     njre.install(targetJavaVersion, {type: bundleType, javafx: javafx}).then(function(dir) {
         var _javaHome = getJavaHomeInPath(dir);
         if (_javaHome == null)


### PR DESCRIPTION
MCP servers use stdout for JSON-RPC protocol communication. Progress messages written to stdout would corrupt the protocol. Changed the "Downloading java runtime environment" message to use console.error (stderr) instead of console.log (stdout).