### PR TITLE
feat: add jdeploy.mode=npx system property to npm launcher

### DIFF
--- a/cli/src/main/resources/ca/weblite/jdeploy/jdeploy.js
+++ b/cli/src/main/resources/ca/weblite/jdeploy/jdeploy.js
@@ -588,6 +588,7 @@ function run(_javaHome) {
 
     var userArgs = process.argv.slice(2);
     var javaArgs = [];
+    javaArgs.push('-Djdeploy.mode=npx');
     javaArgs.push('-Djdeploy.base='+__dirname);
     javaArgs.push('-Djdeploy.port='+port);
     javaArgs.push('-Djdeploy.war.path='+warPath);


### PR DESCRIPTION
Allows apps to detect at runtime whether they were launched via npm/npx (mode=npx) or via the native GUI launcher (mode=gui/cli/service/command).