### PR TITLE
feat: add configurable updateTrigger for CLI commands

### DIFF
--- a/installer/src/main/java/ca/weblite/jdeploy/installer/cli/LinuxCliCommandInstaller.java
+++ b/installer/src/main/java/ca/weblite/jdeploy/installer/cli/LinuxCliCommandInstaller.java
@@ -266,10 +266,11 @@ public class LinuxCliCommandInstaller extends AbstractUnixCliCommandInstaller {
         if (hasUpdater || hasServiceController) {
             // Generate conditional script with checks
 
-            // Check for updater: single "update" argument
+            // Check for updater: single argument matching the configured trigger
             if (hasUpdater) {
-                sb.append("# Check if single argument is \"update\"\n");
-                sb.append("if [ \"$#\" -eq 1 ] && [ \"$1\" = \"update\" ]; then\n");
+                String trigger = command.getUpdateTrigger();
+                sb.append("# Check if single argument is \"").append(trigger).append("\"\n");
+                sb.append("if [ \"$#\" -eq 1 ] && [ \"$1\" = \"").append(trigger).append("\" ]; then\n");
                 sb.append("  exec \"").append(escapedLauncher).append("\" --jdeploy:update\n");
                 sb.append("fi\n\n");
             }

--- a/installer/src/main/java/ca/weblite/jdeploy/installer/cli/MacCliCommandInstaller.java
+++ b/installer/src/main/java/ca/weblite/jdeploy/installer/cli/MacCliCommandInstaller.java
@@ -243,10 +243,11 @@ public class MacCliCommandInstaller extends AbstractUnixCliCommandInstaller {
         if (hasUpdater || hasServiceController) {
             // Generate conditional script with checks
 
-            // Check for updater: single "update" argument
+            // Check for updater: single argument matching the configured trigger
             if (hasUpdater) {
-                sb.append("# Check if single argument is \"update\"\n");
-                sb.append("if [ \"$#\" -eq 1 ] && [ \"$1\" = \"update\" ]; then\n");
+                String trigger = command.getUpdateTrigger();
+                sb.append("# Check if single argument is \"").append(trigger).append("\"\n");
+                sb.append("if [ \"$#\" -eq 1 ] && [ \"$1\" = \"").append(trigger).append("\" ]; then\n");
                 sb.append("  exec \"").append(escapedLauncher).append("\" --jdeploy:update\n");
                 sb.append("fi\n\n");
             }

--- a/installer/src/main/java/ca/weblite/jdeploy/installer/cli/WindowsCliCommandInstaller.java
+++ b/installer/src/main/java/ca/weblite/jdeploy/installer/cli/WindowsCliCommandInstaller.java
@@ -541,10 +541,11 @@ public class WindowsCliCommandInstaller implements CliCommandInstaller {
             // Enable delayed expansion so !errorlevel! works correctly inside if blocks
             sb.append("setlocal enabledelayedexpansion\r\n");
 
-            // Check for updater: single "update" argument
+            // Check for updater: single argument matching the configured trigger
             if (hasUpdater) {
-                sb.append("REM Check if single argument is \"update\"\r\n");
-                sb.append("if \"%~1\"==\"update\" if \"%~2\"==\"\" (\r\n");
+                String trigger = command.getUpdateTrigger();
+                sb.append("REM Check if single argument is \"").append(trigger).append("\"\r\n");
+                sb.append("if \"%~1\"==\"").append(trigger).append("\" if \"%~2\"==\"\" (\r\n");
                 sb.append("  \"").append(launcherPathStr).append("\" --jdeploy:update\r\n");
                 sb.append("  exit /b !errorlevel!\r\n");
                 sb.append(")\r\n\r\n");
@@ -629,10 +630,11 @@ public class WindowsCliCommandInstaller implements CliCommandInstaller {
         if (hasUpdater || hasServiceController) {
             // Generate conditional shell script
 
-            // Check for updater: single "update" argument
+            // Check for updater: single argument matching the configured trigger
             if (hasUpdater) {
-                sb.append("# Check if single argument is \"update\"\n");
-                sb.append("if [ \"$#\" -eq 1 ] && [ \"$1\" = \"update\" ]; then\n");
+                String trigger = command.getUpdateTrigger();
+                sb.append("# Check if single argument is \"").append(trigger).append("\"\n");
+                sb.append("if [ \"$#\" -eq 1 ] && [ \"$1\" = \"").append(trigger).append("\" ]; then\n");
                 sb.append("  exec \"").append(msysLauncherPath).append("\" --jdeploy:update\n");
                 sb.append("fi\n\n");
             }

--- a/shared/src/main/java/ca/weblite/jdeploy/models/CommandSpec.java
+++ b/shared/src/main/java/ca/weblite/jdeploy/models/CommandSpec.java
@@ -9,13 +9,19 @@ import java.util.Objects;
  * Immutable specification for a CLI command installed by the installer.
  */
 public class CommandSpec {
+    /**
+     * Default trigger argument for the updater implementation.
+     */
+    public static final String DEFAULT_UPDATE_TRIGGER = "update";
+
     private final String name;
     private final String description;
     private final List<String> args;
     private final List<String> implementations;
     private final Boolean embedPlist;
+    private final String updateTrigger;
 
-    public CommandSpec(String name, String description, List<String> args, List<String> implementations, Boolean embedPlist) {
+    public CommandSpec(String name, String description, List<String> args, List<String> implementations, Boolean embedPlist, String updateTrigger) {
         if (name == null) {
             throw new IllegalArgumentException("Command name cannot be null");
         }
@@ -32,17 +38,22 @@ public class CommandSpec {
             this.implementations = Collections.unmodifiableList(new ArrayList<>(implementations));
         }
         this.embedPlist = embedPlist;
+        this.updateTrigger = (updateTrigger != null && !updateTrigger.isEmpty()) ? updateTrigger : DEFAULT_UPDATE_TRIGGER;
+    }
+
+    public CommandSpec(String name, String description, List<String> args, List<String> implementations, Boolean embedPlist) {
+        this(name, description, args, implementations, embedPlist, null);
     }
 
     public CommandSpec(String name, String description, List<String> args, List<String> implementations) {
-        this(name, description, args, implementations, null);
+        this(name, description, args, implementations, null, null);
     }
 
     /**
      * Constructor for backward compatibility (no implementations specified).
      */
     public CommandSpec(String name, String description, List<String> args) {
-        this(name, description, args, null, null);
+        this(name, description, args, null, null, null);
     }
 
     public String getName() {
@@ -82,6 +93,17 @@ public class CommandSpec {
         return embedPlist;
     }
 
+    /**
+     * Returns the trigger argument that activates the updater implementation.
+     * When the command is invoked with this single argument, it triggers the
+     * {@code --jdeploy:update} launcher flag.
+     *
+     * @return the update trigger argument, defaults to "update"
+     */
+    public String getUpdateTrigger() {
+        return updateTrigger;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -92,12 +114,13 @@ public class CommandSpec {
                Objects.equals(description, that.description) &&
                Objects.equals(args, that.args) &&
                Objects.equals(implementations, that.implementations) &&
-               Objects.equals(embedPlist, that.embedPlist);
+               Objects.equals(embedPlist, that.embedPlist) &&
+               Objects.equals(updateTrigger, that.updateTrigger);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, args, implementations, embedPlist);
+        return Objects.hash(name, description, args, implementations, embedPlist, updateTrigger);
     }
 
     @Override
@@ -108,6 +131,7 @@ public class CommandSpec {
                 ", args=" + args +
                 ", implementations=" + implementations +
                 ", embedPlist=" + embedPlist +
+                ", updateTrigger='" + updateTrigger + '\'' +
                 '}';
     }
 }

--- a/shared/src/test/java/ca/weblite/jdeploy/models/CommandSpecTest.java
+++ b/shared/src/test/java/ca/weblite/jdeploy/models/CommandSpecTest.java
@@ -229,4 +229,88 @@ public class CommandSpecTest {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("Command not found: " + name));
     }
+
+    // ===== updateTrigger tests =====
+
+    @Test
+    public void testUpdateTriggerDefaultsToUpdate() {
+        CommandSpec cs = new CommandSpec("cmd", null, null);
+        assertEquals(CommandSpec.DEFAULT_UPDATE_TRIGGER, cs.getUpdateTrigger());
+        assertEquals("update", cs.getUpdateTrigger());
+    }
+
+    @Test
+    public void testUpdateTriggerCanBeCustomized() {
+        CommandSpec cs = new CommandSpec("cmd", null, null, null, null, "upgrade");
+        assertEquals("upgrade", cs.getUpdateTrigger());
+    }
+
+    @Test
+    public void testUpdateTriggerNullDefaultsToUpdate() {
+        CommandSpec cs = new CommandSpec("cmd", null, null, null, null, null);
+        assertEquals("update", cs.getUpdateTrigger());
+    }
+
+    @Test
+    public void testUpdateTriggerEmptyDefaultsToUpdate() {
+        CommandSpec cs = new CommandSpec("cmd", null, null, null, null, "");
+        assertEquals("update", cs.getUpdateTrigger());
+    }
+
+    @Test
+    public void testUpdateTriggerIncludedInEquals() {
+        CommandSpec cs1 = new CommandSpec("cmd", null, null, null, null, "upgrade");
+        CommandSpec cs2 = new CommandSpec("cmd", null, null, null, null, "upgrade");
+        CommandSpec cs3 = new CommandSpec("cmd", null, null, null, null, "refresh");
+        assertEquals(cs1, cs2);
+        assertNotEquals(cs1, cs3);
+    }
+
+    @Test
+    public void testUpdateTriggerIncludedInHashCode() {
+        CommandSpec cs1 = new CommandSpec("cmd", null, null, null, null, "upgrade");
+        CommandSpec cs2 = new CommandSpec("cmd", null, null, null, null, "upgrade");
+        CommandSpec cs3 = new CommandSpec("cmd", null, null, null, null, "refresh");
+        assertEquals(cs1.hashCode(), cs2.hashCode());
+        assertNotEquals(cs1.hashCode(), cs3.hashCode());
+    }
+
+    @Test
+    public void testUpdateTriggerIncludedInToString() {
+        CommandSpec cs = new CommandSpec("cmd", null, null, null, null, "upgrade");
+        String s = cs.toString();
+        assertTrue(s.contains("upgrade"));
+        assertTrue(s.contains("updateTrigger"));
+    }
+
+    @Test
+    public void testParserExtractsUpdateTrigger() {
+        JSONObject config = new JSONObject();
+        JSONObject commands = new JSONObject();
+        JSONObject cmdSpec = new JSONObject();
+        cmdSpec.put("implements", new JSONArray().put("updater"));
+        cmdSpec.put("updateTrigger", "upgrade");
+        commands.put("mycmd", cmdSpec);
+        config.put("commands", commands);
+
+        List<CommandSpec> result = CommandSpecParser.parseCommands(config);
+        assertEquals(1, result.size());
+        CommandSpec cmd = result.get(0);
+        assertEquals("upgrade", cmd.getUpdateTrigger());
+    }
+
+    @Test
+    public void testParserDefaultsUpdateTriggerWhenNotSpecified() {
+        JSONObject config = new JSONObject();
+        JSONObject commands = new JSONObject();
+        JSONObject cmdSpec = new JSONObject();
+        cmdSpec.put("implements", new JSONArray().put("updater"));
+        commands.put("mycmd", cmdSpec);
+        config.put("commands", commands);
+
+        List<CommandSpec> result = CommandSpecParser.parseCommands(config);
+        assertEquals(1, result.size());
+        CommandSpec cmd = result.get(0);
+        assertEquals("update", cmd.getUpdateTrigger());
+    }
 }


### PR DESCRIPTION
Add updateTrigger field to CommandSpec allowing customization of the argument that triggers the updater implementation. Previously hard-coded to "update", users can now configure this via package.json. Defaults to "update" for backward compatibility.

Example usage in package.json:
  "commands": {
    "myapp": {
      "implements": ["updater"],
      "updateTrigger": "upgrade"
    }
  }