### PR TITLE
fix: update Node to 20.x and upgrade npm for trusted publishing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -117,10 +117,15 @@ runs:
         git config user.email "<>"
     - name: Set up Node
       if: ${{ env.JDEPLOY_SKIP_EXECUTION != 'true' }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
-        node-version: '16.x'
+        node-version: '20.x'
         registry-url: 'https://registry.npmjs.org'
+
+    - name: Upgrade npm for trusted publishing
+      if: ${{ env.JDEPLOY_SKIP_EXECUTION != 'true' }}
+      run: npm install -g npm@latest
+      shell: bash
 
     - name: Setup jDeploy Registry
       if: ${{ env.JDEPLOY_SKIP_EXECUTION != 'true' }}


### PR DESCRIPTION
## Summary

- **Update `actions/setup-node` from v2 to v4** and **Node from 16.x to 20.x** in the GitHub Action (`action.yml`)
- **Add `npm install -g npm@latest` step** after Node setup to ensure npm supports trusted publishing (OIDC provenance requires npm 9.5+)
- Node 16 ships with npm 8.x which lacks trusted publishing support, breaking `deploy_target: npm` workflows that rely on OIDC provenance

This matches the pattern already used in jDeploy's own CI workflow (`.github/workflows/maven.yml` lines 33-38).

## Test plan

- [ ] Verify GitHub Action runs successfully with `deploy_target: github`
- [ ] Verify GitHub Action runs successfully with `deploy_target: npm` using trusted publishing (OIDC)
- [ ] Confirm npm version after upgrade step is 9.5+ (supporting `--provenance`)

https://claude.ai/code/session_013qz1NYPTSvpAWsjdDXZqLk