### PR TITLE
fix: surface GitHub auth failures and allow skipping repo creation

### DIFF
--- a/cli/src/main/java/ca/weblite/jdeploy/builders/ProjectGeneratorRequestBuilder.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/builders/ProjectGeneratorRequestBuilder.java
@@ -19,6 +19,9 @@ public class ProjectGeneratorRequestBuilder implements ProjectGeneratorRequest.P
     @CommandLineParser.Help("Whether the repository should be private")
     private boolean privateRepository;
 
+    @CommandLineParser.Help("Whether to create the GitHub repository. If false, the repository is assumed to already exist and is only used as the push target. Defaults to true.")
+    private boolean createGitHubRepository = true;
+
     @CommandLineParser.Help("Whether to use an existing directory")
     private boolean useExistingDirectory;
 
@@ -392,6 +395,18 @@ public class ProjectGeneratorRequestBuilder implements ProjectGeneratorRequest.P
         this.privateRepository = privateRepository;
 
         return this;
+    }
+
+    @Override
+    public ProjectGeneratorRequest.Params setCreateGitHubRepository(boolean createGitHubRepository) {
+        this.createGitHubRepository = createGitHubRepository;
+
+        return this;
+    }
+
+    @Override
+    public boolean isCreateGitHubRepository() {
+        return createGitHubRepository;
     }
 
     public String getGithubRepository() {

--- a/cli/src/main/java/ca/weblite/jdeploy/dtos/ProjectGeneratorRequest.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/dtos/ProjectGeneratorRequest.java
@@ -23,6 +23,8 @@ public class ProjectGeneratorRequest {
 
     private final boolean privateRepository;
 
+    private final boolean createGitHubRepository;
+
     private final boolean useExistingDirectory;
 
     public File getParentDirectory() {
@@ -73,6 +75,10 @@ public class ProjectGeneratorRequest {
         return privateRepository;
     }
 
+    public boolean isCreateGitHubRepository() {
+        return createGitHubRepository;
+    }
+
     public boolean isUseExistingDirectory() {
         return useExistingDirectory;
     }
@@ -85,6 +91,9 @@ public class ProjectGeneratorRequest {
         @CommandLineParser.Help("Whether the repository should be private")
         @CommandLineParser.Alias("p")
         boolean isPrivateRepository();
+
+        @CommandLineParser.Help("Whether to create the GitHub repository. If false, the repository is assumed to already exist and is only used as the push target. Defaults to true.")
+        boolean isCreateGitHubRepository();
 
         @CommandLineParser.Help("Use existing directory")
         @CommandLineParser.Alias("e")
@@ -161,6 +170,8 @@ public class ProjectGeneratorRequest {
 
         Params setPrivateRepository(boolean privateRepository);
 
+        Params setCreateGitHubRepository(boolean createGitHubRepository);
+
         Params setUseExistingDirectory(boolean useExistingDirectory);
 
         Params setExtensions(String[] extensions);
@@ -182,6 +193,7 @@ public class ProjectGeneratorRequest {
         this.extensions = params.getExtensions();
         this.githubRepository = params.getGithubRepository();
         this.privateRepository = params.isPrivateRepository();
+        this.createGitHubRepository = params.isCreateGitHubRepository();
         this.useExistingDirectory = params.isUseExistingDirectory();
     }
 }

--- a/cli/src/main/java/ca/weblite/jdeploy/services/GitHubAuthenticationException.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/services/GitHubAuthenticationException.java
@@ -1,0 +1,21 @@
+package ca.weblite.jdeploy.services;
+
+import java.io.IOException;
+
+/**
+ * Thrown when a GitHub API request fails because of invalid, expired or missing
+ * credentials (HTTP 401). It extends {@link IOException} so existing callers
+ * continue to work, while allowing callers that care about authentication to
+ * distinguish a bad token from other I/O errors and prompt the user to
+ * re-authenticate.
+ */
+public class GitHubAuthenticationException extends IOException {
+
+    public GitHubAuthenticationException(String message) {
+        super(message);
+    }
+
+    public GitHubAuthenticationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/cli/src/main/java/ca/weblite/jdeploy/services/GitHubRepositoryInitializer.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/services/GitHubRepositoryInitializer.java
@@ -89,17 +89,24 @@ public class GitHubRepositoryInitializer {
                         "Repository '" + githubRepositoryDto.getFullRepositoryName() + "' created successfully."
                 );
             } else {
-                try (BufferedReader errorReader = new BufferedReader(
-                        new InputStreamReader(connection.getErrorStream()))
-                ) {
-                    StringBuilder errorMessage = new StringBuilder();
-                    String line;
-                    while ((line = errorReader.readLine()) != null) {
-                        errorMessage.append(line);
+                StringBuilder errorMessage = new StringBuilder();
+                if (connection.getErrorStream() != null) {
+                    try (BufferedReader errorReader = new BufferedReader(
+                            new InputStreamReader(connection.getErrorStream()))
+                    ) {
+                        String line;
+                        while ((line = errorReader.readLine()) != null) {
+                            errorMessage.append(line);
+                        }
                     }
-                    throw new IOException("Failed to create the repository. " +
-                            "Response code: " + responseCode + ", Error message: " + errorMessage);
                 }
+                if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                    throw new GitHubAuthenticationException("Failed to create the repository. " +
+                            "GitHub rejected the credentials (HTTP 401). Your GitHub token may be " +
+                            "missing, invalid or expired. Error message: " + errorMessage);
+                }
+                throw new IOException("Failed to create the repository. " +
+                        "Response code: " + responseCode + ", Error message: " + errorMessage);
             }
         } finally {
             connection.disconnect();

--- a/cli/src/main/java/ca/weblite/jdeploy/services/GitHubUsernameService.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/services/GitHubUsernameService.java
@@ -46,6 +46,10 @@ public class GitHubUsernameService {
                 return jsonResponse.getString("login");
             }
         } else {
+            if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                throw new GitHubAuthenticationException("Failed to authenticate with GitHub (HTTP 401). " +
+                        "Your GitHub token may be missing, invalid or expired.");
+            }
             throw new IOException("Failed to retrieve GitHub username. Response code: " + responseCode);
         }
     }

--- a/cli/src/main/java/ca/weblite/jdeploy/services/ProjectGenerator.java
+++ b/cli/src/main/java/ca/weblite/jdeploy/services/ProjectGenerator.java
@@ -70,52 +70,66 @@ public class ProjectGenerator {
         if (!request.isUseExistingDirectory() && projectDir.exists() ) {
             throw new Exception("Project directory already exists: " + projectDir.getAbsolutePath());
         }
+        // Track whether we created the directory so we can clean it up if a later
+        // step fails (e.g. a GitHub authentication error), rather than leaving a
+        // half-generated project behind that blocks the user from retrying.
+        boolean projectDirCreated = !request.isUseExistingDirectory();
         projectDir.mkdirs();
         if (!projectDir.exists()) {
             throw new IOException("Failed to create project directory: " + projectDir.getAbsolutePath());
         }
 
-        String templateDirectory = request.getTemplateDirectory();
-        if (templateDirectory == null && request.getTemplateName() != null) {
-            projectTemplateCatalog.update();
-            templateDirectory = projectTemplateCatalog.getProjectTemplate(request.getTemplateName()).getAbsolutePath();
-        }
-        if (templateDirectory == null) {
-            throw new Exception("Template directory is not set");
-        }
-
-        File templateDir = new File(templateDirectory);
-        if ( !templateDir.exists() ) {
-            throw new Exception("Template directory does not exist: " + templateDir.getAbsolutePath());
-        }
-        File[] files = templateDir.listFiles();
-        if (files == null) {
-            throw new IOException("Failed to get files in template directory: " + templateDir.getAbsolutePath());
-        }
-        for ( File file : files) {
-            if ( file.isDirectory() ) {
-                FileUtils.copyDirectory(file, new File(projectDir, file.getName()));
-            } else {
-                FileUtils.copyFileToDirectory(file, projectDir);
+        try {
+            String templateDirectory = request.getTemplateDirectory();
+            if (templateDirectory == null && request.getTemplateName() != null) {
+                projectTemplateCatalog.update();
+                templateDirectory = projectTemplateCatalog.getProjectTemplate(request.getTemplateName()).getAbsolutePath();
             }
-        }
-        if (request.getExtensions() != null) {
-            for (String extension : request.getExtensions()) {
-                File extensionDir = projectTemplateCatalog.getExtensionTemplate(extension);
-                applyExtensionToProject(projectDir, extensionDir);
-
+            if (templateDirectory == null) {
+                throw new Exception("Template directory is not set");
             }
+
+            File templateDir = new File(templateDirectory);
+            if ( !templateDir.exists() ) {
+                throw new Exception("Template directory does not exist: " + templateDir.getAbsolutePath());
+            }
+            File[] files = templateDir.listFiles();
+            if (files == null) {
+                throw new IOException("Failed to get files in template directory: " + templateDir.getAbsolutePath());
+            }
+            for ( File file : files) {
+                if ( file.isDirectory() ) {
+                    FileUtils.copyDirectory(file, new File(projectDir, file.getName()));
+                } else {
+                    FileUtils.copyFileToDirectory(file, projectDir);
+                }
+            }
+            if (request.getExtensions() != null) {
+                for (String extension : request.getExtensions()) {
+                    File extensionDir = projectTemplateCatalog.getExtensionTemplate(extension);
+                    applyExtensionToProject(projectDir, extensionDir);
+
+                }
+            }
+
+            updateFilesInDirectory(projectDir, request);
+            updatePackageJsonWithGithubSettings(projectDir, request);
+
+            if (mavenWrapperInjector.isMavenProject(projectDir.getPath())) {
+                mavenWrapperInjector.installIntoProject(projectDir.getPath());
+            }
+
+            initializeAndPushGitRepository(projectDir, request);
+            return projectDir;
+        } catch (Exception e) {
+            if (projectDirCreated) {
+                FileUtils.deleteQuietly(projectDir);
+                FileUtils.deleteQuietly(
+                        new File(projectDir.getParentFile(), projectDir.getName() + "-releases")
+                );
+            }
+            throw e;
         }
-
-        updateFilesInDirectory(projectDir, request);
-        updatePackageJsonWithGithubSettings(projectDir, request);
-
-        if (mavenWrapperInjector.isMavenProject(projectDir.getPath())) {
-            mavenWrapperInjector.installIntoProject(projectDir.getPath());
-        }
-
-        initializeAndPushGitRepository(projectDir, request);
-        return projectDir;
 
     }
 
@@ -191,7 +205,9 @@ public class ProjectGenerator {
         requestBuilder.setRepoName(request.getGithubRepository())
                 .setProjectPath(projectDirectory.getAbsolutePath())
                 .setPrivate(request.isPrivateRepository());
-        gitHubRepositoryInitializer.createGitHubRepository(requestBuilder.build());
+        if (request.isCreateGitHubRepository()) {
+            gitHubRepositoryInitializer.createGitHubRepository(requestBuilder.build());
+        }
 
         if (request.isPrivateRepository()) {
             addSecretToWorkflow(request);


### PR DESCRIPTION
## Summary

This is the CLI-side half of a two-PR fix for the GitHub "Bad credentials" (HTTP 401) problem reported in **shannah/jdeploy-desktop-gui#80**, where the desktop GUI fails to create a project with a 401 and never offers a way to fix the credentials. The companion GUI PR is shannah/jdeploy-desktop-gui (branch `claude/sleepy-thompson-sl3q4`).

These changes make the CLI's GitHub integration easier to recover from and less destructive on failure.

## Changes

1. **Typed authentication failure** — new `GitHubAuthenticationException` (a subclass of `IOException`, so existing `catch (IOException)` callers are unaffected). `GitHubRepositoryInitializer.createGitHubRepository()` and `GitHubUsernameService.getGitHubUsername()` now throw it on HTTP 401, so callers (e.g. the desktop GUI) can distinguish an invalid/expired token from other I/O errors and prompt the user to re-authenticate.

2. **Optional repository creation** — added a `createGitHubRepository` flag to `ProjectGeneratorRequest`/`ProjectGeneratorRequestBuilder` (**defaults to `true`**, so existing behaviour is unchanged). When `false`, `ProjectGenerator` skips the `POST /user/repos` call and uses the repository purely as a push target. This lets a project target an already-existing repo without attempting to create it.

3. **Rollback on failure** — `ProjectGenerator.generate()` now deletes the freshly-created project directory (and its `-releases` sibling) if generation fails after the directory was created. Previously a failed attempt (e.g. a 401 during repo creation) left the directory on disk, which then tripped the "Project directory already exists" check on the next attempt.

## Testing

- `mvn -pl shared,cli -am install` — builds cleanly.
- `mvn -pl cli test` (integration tests skipped) — passes.

Existing behaviour is preserved: the new flag defaults to `true` and the new exception is an `IOException` subtype.

https://claude.ai/code/session_0156xouo4EmaKjSihdHSDXxF

---
_Generated by [Claude Code](https://claude.ai/code/session_0156xouo4EmaKjSihdHSDXxF)_