### PR TITLE
fix: pin npm to v11 and bump Node to 22.x to avoid npm@latest engine break

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,9 +33,11 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '22.x'
     - name: Upgrade npm for trusted publishing
-      run: npm install -g npm@latest
+      # Pin the npm major version instead of tracking npm@latest so a new npm
+      # release with a higher Node engine requirement can't break this step.
+      run: npm install -g npm@11
     - name: Install PHP
       run: |
         brew update

--- a/action.yml
+++ b/action.yml
@@ -119,12 +119,16 @@ runs:
       if: ${{ env.JDEPLOY_SKIP_EXECUTION != 'true' }}
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '22.x'
         registry-url: 'https://registry.npmjs.org'
 
     - name: Upgrade npm for trusted publishing
-      if: ${{ env.JDEPLOY_SKIP_EXECUTION != 'true' }}
-      run: npm install -g npm@latest
+      # Only needed for npm trusted publishing (OIDC provenance); GitHub
+      # releases don't use it. Pin the major version rather than tracking
+      # npm@latest so a new npm release with a higher Node engine requirement
+      # can't break this step without a Node bump here.
+      if: ${{ env.JDEPLOY_SKIP_EXECUTION != 'true' && inputs.deploy_target == 'npm' }}
+      run: npm install -g npm@11
       shell: bash
 
     - name: Setup jDeploy Registry


### PR DESCRIPTION
npm published v12.0.0 as "latest", which requires Node ^22.22.2 || ^24.15.0
|| >=26. The action provisioned Node 20.x and ran `npm install -g npm@latest`,
so every consumer pinned to shannah/jdeploy@master started failing with
EBADENGINE the moment npm 12 shipped, with no change on their side.

- Pin the upgrade to `npm@11` instead of tracking `npm@latest` so a future
  npm major with a higher Node engine requirement can't silently break the
  action again.
- Bump Node from 20.x to 22.x, clearing the runner's Node 20 deprecation
  warning while staying compatible with npm 11's trusted-publishing (OIDC).
- Gate the npm upgrade in action.yml on `deploy_target == 'npm'` since
  trusted publishing is npm-registry-only; GitHub-only releases skip it.

Applied the same pin/Node bump to the internal maven.yml release workflow.