### PR TITLE
fix: drop icp4/icp5 icns slices that macOS renders scrambled

### DIFF
--- a/shared/src/main/java/com/joshondesign/appbundler/mac/MacBundler.java
+++ b/shared/src/main/java/com/joshondesign/appbundler/mac/MacBundler.java
@@ -575,11 +575,18 @@ public class MacBundler {
                 .toFile(new File(contentsDir, "icon-"+size+".png"));
     }
     
-    /** icns slice types each rendered size fills; the @2x types let one file serve two entries */
-    private static final int[] ICON_SIZES = {16, 32, 64, 128, 256, 512, 1024};
+    /**
+     * icns slice types each rendered size fills; the @2x types let one file serve two entries.
+     *
+     * <p>icp4 (16x16) and icp5 (32x32) are deliberately absent.  macOS reads a PNG payload in
+     * those two slices correctly from a standalone icns, but renders it scrambled when the icns
+     * is an app bundle's icon - which is why the Finder preview pane looked right while the
+     * Finder list view and the Force Quit dialog did not.  ic11 and ic12 carry the small
+     * renderings instead, and macOS interpolates the 16pt/32pt non-retina sizes from them.</p>
+     */
+    private static final int[] ICON_SIZES = {32, 64, 128, 256, 512, 1024};
     private static final IcnsType[][] ICON_TYPES = {
-            {IcnsType.ICNS_16x16_JPEG_PNG_IMAGE},
-            {IcnsType.ICNS_32x32_JPEG_PNG_IMAGE, IcnsType.ICNS_16x16_2X_JPEG_PNG_IMAGE},
+            {IcnsType.ICNS_16x16_2X_JPEG_PNG_IMAGE},
             // no icp6: macOS reads that type as 48x48, and its icon set has no 64pt logical size
             {IcnsType.ICNS_32x32_2X_JPEG_PNG_IMAGE},
             {IcnsType.ICNS_128x128_JPEG_PNG_IMAGE},
@@ -594,14 +601,46 @@ public class MacBundler {
         }
     }
 
-    /** rendered size the given slice type holds, or 0 if it isn't one we generate */
-    private static int getIconSize(String osType) {
-        for (int i = 0; i < ICON_SIZES.length; i++) {
-            for (IcnsType type : ICON_TYPES[i]) {
-                if (type.getOsType().equals(osType)) return ICON_SIZES[i];
+    /** pixel size of the source icon, from the slice type {@link #getOsType} matched it to */
+    private static int getSourceSize(String osType) {
+        IcnsType sourceType = IcnsType.of(osType);
+
+        return sourceType == null ? 0 : sourceType.getWidth();
+    }
+
+    /**
+     * Writes the icns for the given source icon, one slice per rendered size at or below the
+     * source's own size - upscaling would tag a blurry slice as a native rendering.
+     *
+     * <p>A source too small to fill any slice we emit (16x16, and 32x32 non-square sources that
+     * {@link #getOsType} resized) falls back to a single slice of its own type: scrambled beats
+     * an icns with no icon in it at all.</p>
+     */
+    static void writeIcns(File iconFile, File contentsDir, String osType, File icnsFile) throws IOException {
+        int maxSize = getSourceSize(osType);
+        if (maxSize > 0) {
+            createThumbnails(iconFile, contentsDir, maxSize);
+        }
+        try (IcnsBuilder builder = IcnsBuilder.getInstance()) {
+            boolean wroteAnySlice = false;
+            for (int i = 0; i < ICON_SIZES.length && ICON_SIZES[i] <= maxSize; i++) {
+                for (IcnsType type : ICON_TYPES[i]) {
+                    try (InputStream in = getThumbnail(contentsDir, ICON_SIZES[i])) {
+                        builder.add(type.getOsType(), in);
+                    }
+                    wroteAnySlice = true;
+                }
+            }
+            if (!wroteAnySlice) {
+                try (InputStream in = new FileInputStream(iconFile)) {
+                    builder.add(osType, in);
+                }
+            }
+            try (FileOutputStream out = new FileOutputStream(icnsFile)) {
+                builder.build().writeTo(out);
             }
         }
-        return 0;
+        cleanThumbnails(contentsDir);
     }
     
     private static FileInputStream getThumbnail(File contentsDir, int size) throws IOException {
@@ -758,36 +797,13 @@ public class MacBundler {
         if (osType == null) {
             throw new IOException("Failed to determine type of icon file.");
         }
-       
-        
-        // macOS 26 draws a single-slice icns shrunk onto a grey plate, so write the whole size family
-        int maxSize = getIconSize(osType);
-        if (maxSize > 0) createThumbnails(iconFile, contentsDir, maxSize);
-        try (IcnsBuilder builder = IcnsBuilder.getInstance()) {
-            if (maxSize == 0) {
-                builder.add(osType, new FileInputStream(iconFile));
-            } else {
-                // only down to the source size - upscaling would tag a blurry slice as native
-                for (int i = 0; i < ICON_SIZES.length && ICON_SIZES[i] <= maxSize; i++) {
-                    for (IcnsType type : ICON_TYPES[i]) {
-                        try (InputStream in = getThumbnail(contentsDir, ICON_SIZES[i])) {
-                            builder.add(type.getOsType(), in);
-                        }
-                    }
-                }
-            }
-            File icnsFile = ext != null ?
-                    new File(contentsDir, "Resources/icon."+ext+".icns") :
-                    new File(contentsDir, "Resources/icon.icns");
-            try (FileOutputStream out = new FileOutputStream(icnsFile)) {
-                builder.build().writeTo(out);
-            }
 
-        }
+        // macOS 26 draws a single-slice icns shrunk onto a grey plate, so write the whole size family
+        File icnsFile = ext != null ?
+                new File(contentsDir, "Resources/icon."+ext+".icns") :
+                new File(contentsDir, "Resources/icon.icns");
+        writeIcns(iconFile, contentsDir, osType, icnsFile);
         iconFile.delete();
-        cleanThumbnails(contentsDir);
-                    
-        
     }
     
     private static void processInfoPlist(AppDescription app, File contentsDir) throws Exception {

--- a/shared/src/test/java/com/joshondesign/appbundler/mac/MacBundlerIconTest.java
+++ b/shared/src/test/java/com/joshondesign/appbundler/mac/MacBundlerIconTest.java
@@ -1,0 +1,149 @@
+package com.joshondesign.appbundler.mac;
+
+import com.github.gino0631.icns.IcnsIcons;
+import com.github.gino0631.icns.IcnsType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the icns slice family that {@link MacBundler} writes for a mac app bundle's icon.
+ */
+public class MacBundlerIconTest {
+
+    /**
+     * macOS renders a PNG payload in these slices scrambled when the icns is an app bundle's
+     * icon, so they must never appear in a bundle we build.
+     */
+    private static final List<String> SCRAMBLED_TYPES = java.util.Arrays.asList("icp4", "icp5", "icp6");
+
+    @TempDir
+    File contentsDir;
+
+    private File icnsFile;
+
+    @BeforeEach
+    public void setUp() {
+        icnsFile = new File(contentsDir, "icon.icns");
+    }
+
+    @Test
+    public void doesNotEmitTheSlicesMacOsRendersScrambled() throws Exception {
+        MacBundler.writeIcns(squareIcon(1024), contentsDir, "ic10", icnsFile);
+
+        for (String osType : osTypesIn(icnsFile)) {
+            assertFalse(SCRAMBLED_TYPES.contains(osType),
+                    "icns must not contain " + osType + ", which macOS renders scrambled in an app bundle");
+        }
+    }
+
+    @Test
+    public void coversTheSmallSizesWithTheRetinaSlices() throws Exception {
+        MacBundler.writeIcns(squareIcon(1024), contentsDir, "ic10", icnsFile);
+
+        List<String> osTypes = osTypesIn(icnsFile);
+        // ic11 is 16pt@2x and ic12 is 32pt@2x - the Finder list view and the Force Quit dialog
+        // render from these once icp4/icp5 are gone.
+        assertTrue(osTypes.contains("ic11"), "expected ic11 (16pt@2x) but got " + osTypes);
+        assertTrue(osTypes.contains("ic12"), "expected ic12 (32pt@2x) but got " + osTypes);
+        assertEquals(
+                java.util.Arrays.asList("ic11", "ic12", "ic07", "ic08", "ic13", "ic09", "ic14", "ic10"),
+                osTypes);
+    }
+
+    @Test
+    public void eachSlicePayloadMatchesTheSizeItsTypeDeclares() throws Exception {
+        MacBundler.writeIcns(squareIcon(1024), contentsDir, "ic10", icnsFile);
+
+        try (IcnsIcons icons = IcnsIcons.load(icnsFile.toPath())) {
+            for (IcnsIcons.Entry entry : icons.getEntries()) {
+                IcnsType type = entry.getType();
+                assertNotNull(type, "unknown slice type " + entry.getOsType());
+                BufferedImage payload = ImageIO.read(new java.io.ByteArrayInputStream(bytesOf(entry)));
+                assertNotNull(payload, entry.getOsType() + " payload is not a readable image");
+                assertEquals(type.getWidth(), payload.getWidth(), entry.getOsType() + " width");
+                assertEquals(type.getHeight(), payload.getHeight(), entry.getOsType() + " height");
+            }
+        }
+    }
+
+    @Test
+    public void doesNotUpscaleASourceSmallerThanTheLargestSlice() throws Exception {
+        MacBundler.writeIcns(squareIcon(128), contentsDir, "ic07", icnsFile);
+
+        // ic08/ic13 and up would each be an upscale of the 128px source tagged as native.
+        assertEquals(java.util.Arrays.asList("ic11", "ic12", "ic07"), osTypesIn(icnsFile));
+    }
+
+    @Test
+    public void fallsBackToASingleSliceWhenTheSourceFillsNoneOfThem() throws Exception {
+        // A 16x16 source is smaller than ic11, the smallest slice we emit. An icns with no icon
+        // at all would be worse than the scrambled one, so the source's own type is kept.
+        MacBundler.writeIcns(squareIcon(16), contentsDir, "icp4", icnsFile);
+
+        assertEquals(java.util.Arrays.asList("icp4"), osTypesIn(icnsFile));
+    }
+
+    @Test
+    public void removesTheIntermediateThumbnails() throws Exception {
+        MacBundler.writeIcns(squareIcon(1024), contentsDir, "ic10", icnsFile);
+
+        for (File f : contentsDir.listFiles()) {
+            assertFalse(f.getName().startsWith("icon-") && f.getName().endsWith(".png"),
+                    "left behind thumbnail " + f.getName());
+        }
+    }
+
+    private List<String> osTypesIn(File icns) throws Exception {
+        List<String> osTypes = new ArrayList<>();
+        try (IcnsIcons icons = IcnsIcons.load(icns.toPath())) {
+            for (IcnsIcons.Entry entry : icons.getEntries()) {
+                osTypes.add(entry.getOsType());
+            }
+        }
+
+        return osTypes;
+    }
+
+    private byte[] bytesOf(IcnsIcons.Entry entry) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (InputStream in = entry.newInputStream()) {
+            byte[] buf = new byte[8192];
+            int read;
+            while ((read = in.read(buf)) > 0) {
+                out.write(buf, 0, read);
+            }
+        }
+
+        return out.toByteArray();
+    }
+
+    private File squareIcon(int size) throws Exception {
+        BufferedImage image = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = image.createGraphics();
+        g.setColor(Color.YELLOW);
+        g.fillRect(0, 0, size, size);
+        g.setColor(Color.BLACK);
+        g.fillOval(size / 4, size / 4, size / 2, size / 2);
+        g.dispose();
+        File iconFile = new File(contentsDir, "icon.png");
+        ImageIO.write(image, "png", iconFile);
+
+        return iconFile;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the corrupted small app icon reported against `6.1.0-dev.0` — the icon renders correctly in the Finder preview pane but as garbage in the Finder list view and the Force Quit dialog.

This is a regression from #475, which switched `MacBundler` from writing a single icns slice to writing the whole size family. The family it wrote included `icp4` (16x16) and `icp5` (32x32).

## Root cause

macOS reads a PNG payload in the `icp4`/`icp5` slice types correctly from a **standalone** icns, but renders it **scrambled** when the icns is an **app bundle's** icon. That split is exactly the reported symptom: the Finder preview pane reads the file standalone and looks right, while the list view and Force Quit read the bundle's icon and don't.

This is a long-standing, independently reported macOS behaviour, not a malformed file on our side — see the [png2icons issue](https://github.com/idesis-gmbh/png2icons/issues/1) ("Icons look scrambled in macOS Finder list view"), whose adopted resolution was to *"simply exclude those types from the generation"*, because *"the image interpolation in the Finder (or the OS) manages to display correct images at all sizes, even if the types mentioned above are missing in the ICNS file."*

I verified the generated icns is structurally sound before concluding this — every slice's PNG payload dimensions match the size its OSType declares, all PNG with alpha. So the bug is which types we emit, not how we emit them.

Before #475 only one slice was written (typically `ic09` at 512px), so macOS downscaled it for the small sizes and they looked fine — which is why this regression is new.

## Fix

Emit `ic11` (16pt@2x, 32px) and `ic12` (32pt@2x, 64px) as the smallest slices instead of `icp4`/`icp5`. Those two are unambiguously PNG-only, serve the small sizes natively on retina displays, and macOS interpolates the 16pt/32pt non-retina renderings from them.

The bound on the family — "don't emit a slice larger than the source, upscaling would tag a blurry slice as native" — was previously derived by looking the source's own OSType up in the emit table. That coupling breaks once `icp4`/`icp5` leave the table: a 16x16 or 32x32 source would no longer resolve a bound. The size now comes from the source's own slice type (`IcnsType.of(osType).getWidth()`), independent of what we emit.

A source too small to fill any emitted slice (a 16x16 icon) keeps its single native slice, since an icns with no icon in it at all would be worse than a scrambled one.

The icns writing is extracted into a package-private `writeIcns(...)` so it can be tested directly.

## Testing

New `MacBundlerIconTest` (6 tests, all passing) covering:
- no `icp4`/`icp5`/`icp6` slice is ever emitted
- `ic11` and `ic12` are present, and the full emitted set is exactly `[ic11, ic12, ic07, ic08, ic13, ic09, ic14, ic10]` for a 1024px source
- every slice's payload dimensions match the size its OSType declares
- a 128px source emits only `[ic11, ic12, ic07]` — nothing upscaled
- a 16px source falls back to its single native slice rather than an empty icns
- the intermediate `icon-*.png` thumbnails are cleaned up

I confirmed the tests catch the regression: against the pre-fix slice table 3 of the 6 fail, naming `icp4`/`icp5` in the diff. Full `shared` suite: 234 tests, 0 failures.

## Not fixed here

The other half of the report — the app icon still being **too large in the Cmd-Tab switcher** — is not addressed by this PR, and I don't believe it is fixable by changing which icns slices we write. #475's premise was that macOS 26 shrinks a single-slice icns onto a grey plate, so writing the full family would correct the size; the reporter confirms the size is unchanged with the family present. The switcher/Dock sizing on macOS 26 is governed by Tahoe's icon plate and masking, which expects either an Icon Composer `.icon` asset or source artwork authored with the padding Apple's icon grid assumes — neither of which follows from the icns slice set. That's separate work; happy to dig into it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQuAnJXfX5ZvXTgnHWdPqs

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQuAnJXfX5ZvXTgnHWdPqs)_