### PR TITLE
fix: inset mac app icons onto the macOS icon grid

### DIFF
--- a/shared/src/main/java/com/joshondesign/appbundler/mac/MacBundler.java
+++ b/shared/src/main/java/com/joshondesign/appbundler/mac/MacBundler.java
@@ -12,6 +12,10 @@ import com.client4j.publisher.server.SigningRequest;
 import com.github.gino0631.icns.IcnsBuilder;
 import com.github.gino0631.icns.IcnsType;
 import com.joshondesign.xml.XMLWriter;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 
 import java.io.*;
@@ -601,6 +605,96 @@ public class MacBundler {
         }
     }
 
+    /**
+     * Fraction of the icns canvas that a macOS app icon's artwork is meant to fill.  Apple's
+     * macOS icon template centres an 824x824 body in a 1024x1024 canvas, so every icon the
+     * system draws beside ours - in the Dock, the command-tab switcher, Mission Control - leaves
+     * that margin.  Artwork that runs edge to edge renders about a quarter wider than its
+     * neighbours at the same slot size, which reads as "this app's icon is too big".
+     */
+    private static final double ICON_GRID_SCALE = 824.0 / 1024.0;
+
+    /**
+     * How far past the grid the artwork may already reach before we inset it.  A source that is
+     * already drawn on the grid - or close enough that resampling it would cost more sharpness
+     * than the difference is worth - is passed through untouched.
+     */
+    private static final double ICON_GRID_TOLERANCE = 0.02;
+
+    /** Alpha at or above which a pixel counts as artwork rather than as shadow or fringe. */
+    private static final int ICON_GRID_ALPHA_THRESHOLD = 25;
+
+    /** Name of the grid-fitted source; matches the thumbnail pattern so it is cleaned up too. */
+    static final String GRID_ICON_NAME = "icon-grid.png";
+
+    /**
+     * Returns the source to cut slices from, insetting the artwork onto the macOS icon grid
+     * when it fills more of its canvas than the grid allows.
+     *
+     * <p>The artwork is measured by its opaque bounds rather than by the canvas, so a source
+     * that already carries the margin is returned as-is and one that carries part of it is
+     * scaled the rest of the way rather than twice over.  Non-square and unreadable sources are
+     * left alone, as is one that is fully transparent.</p>
+     */
+    private static File fitToIconGrid(File iconFile, File contentsDir) throws IOException {
+        BufferedImage source = ImageIO.read(iconFile);
+        if (source == null || source.getWidth() != source.getHeight()) {
+            return iconFile;
+        }
+        int canvas = source.getWidth();
+        Rectangle artwork = opaqueBounds(source);
+        if (artwork == null) {
+            return iconFile;
+        }
+        int artworkSize = Math.max(artwork.width, artwork.height);
+        if (artworkSize <= canvas * (ICON_GRID_SCALE + ICON_GRID_TOLERANCE)) {
+            return iconFile;
+        }
+
+        double scale = canvas * ICON_GRID_SCALE / artworkSize;
+        AffineTransform placement = new AffineTransform();
+        placement.translate(
+                (canvas - artwork.width * scale) / 2.0 - artwork.x * scale,
+                (canvas - artwork.height * scale) / 2.0 - artwork.y * scale);
+        placement.scale(scale, scale);
+
+        BufferedImage fitted = new BufferedImage(canvas, canvas, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = fitted.createGraphics();
+        try {
+            g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+            g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g.drawImage(source, placement, null);
+        } finally {
+            g.dispose();
+        }
+
+        File gridFile = new File(contentsDir, GRID_ICON_NAME);
+        ImageIO.write(fitted, "png", gridFile);
+
+        return gridFile;
+    }
+
+    /** Bounds of the artwork in the given image, or null if none of it is opaque enough. */
+    private static Rectangle opaqueBounds(BufferedImage image) {
+        int minX = image.getWidth();
+        int minY = image.getHeight();
+        int maxX = -1;
+        int maxY = -1;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if ((image.getRGB(x, y) >>> 24) < ICON_GRID_ALPHA_THRESHOLD) continue;
+                if (x < minX) minX = x;
+                if (x > maxX) maxX = x;
+                if (y < minY) minY = y;
+                if (y > maxY) maxY = y;
+            }
+        }
+        if (maxX < 0) return null;
+
+        return new Rectangle(minX, minY, maxX - minX + 1, maxY - minY + 1);
+    }
+
     /** pixel size of the source icon, from the slice type {@link #getOsType} matched it to */
     private static int getSourceSize(String osType) {
         IcnsType sourceType = IcnsType.of(osType);
@@ -610,16 +704,19 @@ public class MacBundler {
 
     /**
      * Writes the icns for the given source icon, one slice per rendered size at or below the
-     * source's own size - upscaling would tag a blurry slice as a native rendering.
+     * source's own size - upscaling would tag a blurry slice as a native rendering.  Each slice
+     * is cut from artwork sitting on the macOS icon grid, so the bundle's icon is drawn at the
+     * same size as the system's own icons rather than a quarter larger.
      *
      * <p>A source too small to fill any slice we emit (16x16, and 32x32 non-square sources that
-     * {@link #getOsType} resized) falls back to a single slice of its own type: scrambled beats
-     * an icns with no icon in it at all.</p>
+     * {@link #getOsType} resized) falls back to a single slice of its own type, unchanged:
+     * scrambled beats an icns with no icon in it at all, and insetting artwork that small would
+     * leave almost nothing of it.</p>
      */
     static void writeIcns(File iconFile, File contentsDir, String osType, File icnsFile) throws IOException {
         int maxSize = getSourceSize(osType);
         if (maxSize > 0) {
-            createThumbnails(iconFile, contentsDir, maxSize);
+            createThumbnails(fitToIconGrid(iconFile, contentsDir), contentsDir, maxSize);
         }
         try (IcnsBuilder builder = IcnsBuilder.getInstance()) {
             boolean wroteAnySlice = false;

--- a/shared/src/test/java/com/joshondesign/appbundler/mac/MacBundlerIconTest.java
+++ b/shared/src/test/java/com/joshondesign/appbundler/mac/MacBundlerIconTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.io.TempDir;
 import javax.imageio.ImageIO;
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -100,6 +101,37 @@ public class MacBundlerIconTest {
     }
 
     @Test
+    public void insetsFullBleedArtworkOntoTheIconGrid() throws Exception {
+        MacBundler.writeIcns(squareIcon(1024), contentsDir, "ic10", icnsFile);
+
+        // Apple's macOS template centres an 824x824 body in a 1024x1024 canvas. Artwork drawn
+        // edge to edge renders a quarter wider than every system icon beside it.
+        Rectangle artwork = artworkBoundsOf("ic10");
+        assertEquals(824, artwork.width, 12, "artwork width on the icon grid");
+        assertEquals(824, artwork.height, 12, "artwork height on the icon grid");
+        assertEquals(artwork.x, 1024 - (artwork.x + artwork.width), 2, "artwork is not centred");
+    }
+
+    @Test
+    public void leavesArtworkThatAlreadySitsOnTheGridAlone() throws Exception {
+        // An icon authored to Apple's template already carries the margin; insetting it again
+        // would make it smaller than its neighbours instead of the same size.
+        MacBundler.writeIcns(insetIcon(1024, 700), contentsDir, "ic10", icnsFile);
+
+        Rectangle artwork = artworkBoundsOf("ic10");
+        assertEquals(700, artwork.width, 4, "artwork width should be untouched");
+        assertEquals(700, artwork.height, 4, "artwork height should be untouched");
+    }
+
+    @Test
+    public void removesTheGridFittedSource() throws Exception {
+        MacBundler.writeIcns(squareIcon(1024), contentsDir, "ic10", icnsFile);
+
+        assertFalse(new File(contentsDir, MacBundler.GRID_ICON_NAME).exists(),
+                "left behind " + MacBundler.GRID_ICON_NAME);
+    }
+
+    @Test
     public void removesTheIntermediateThumbnails() throws Exception {
         MacBundler.writeIcns(squareIcon(1024), contentsDir, "ic10", icnsFile);
 
@@ -131,6 +163,53 @@ public class MacBundlerIconTest {
         }
 
         return out.toByteArray();
+    }
+
+    /** Bounds of the non-transparent pixels in the named slice's payload. */
+    private Rectangle artworkBoundsOf(String osType) throws Exception {
+        try (IcnsIcons icons = IcnsIcons.load(icnsFile.toPath())) {
+            for (IcnsIcons.Entry entry : icons.getEntries()) {
+                if (!entry.getOsType().equals(osType)) continue;
+                BufferedImage payload = ImageIO.read(new java.io.ByteArrayInputStream(bytesOf(entry)));
+                assertNotNull(payload, osType + " payload is not a readable image");
+
+                return opaqueBounds(payload);
+            }
+        }
+        throw new AssertionError("no " + osType + " slice in " + icnsFile);
+    }
+
+    private Rectangle opaqueBounds(BufferedImage image) {
+        int minX = image.getWidth();
+        int minY = image.getHeight();
+        int maxX = -1;
+        int maxY = -1;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if ((image.getRGB(x, y) >>> 24) < 25) continue;
+                if (x < minX) minX = x;
+                if (x > maxX) maxX = x;
+                if (y < minY) minY = y;
+                if (y > maxY) maxY = y;
+            }
+        }
+        assertTrue(maxX >= 0, "payload is fully transparent");
+
+        return new Rectangle(minX, minY, maxX - minX + 1, maxY - minY + 1);
+    }
+
+    /** An icon whose artwork occupies {@code artworkSize} of a {@code size} canvas, centred. */
+    private File insetIcon(int size, int artworkSize) throws Exception {
+        BufferedImage image = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = image.createGraphics();
+        int origin = (size - artworkSize) / 2;
+        g.setColor(Color.YELLOW);
+        g.fillRect(origin, origin, artworkSize, artworkSize);
+        g.dispose();
+        File iconFile = new File(contentsDir, "icon.png");
+        ImageIO.write(image, "png", iconFile);
+
+        return iconFile;
     }
 
     private File squareIcon(int size) throws Exception {


### PR DESCRIPTION
## What this fixes

An installed jDeploy app's icon renders visibly larger than the apps beside it in the command-tab switcher, the Dock and Mission Control.

Apple's macOS icon template centres an **824×824 body in a 1024×1024 canvas** — every icon macOS draws next to ours leaves that margin. jDeploy wrote the source artwork into every icns slice edge to edge, so at the same slot size it renders ~24% wider (1024/824) than its neighbours.

## Why it showed up now

Before #475, macOS treated the single-slice icns as legacy and shrank it onto a plate — that supplied a margin by accident. With the full slice family in place macOS draws the artwork as authored, so a full-bleed source now shows at full slot width. #479 fixed the small-slice scrambling but not the size, which is why the icon came back uncorrupted and still oversized.

## Approach

`MacBundler.writeIcns` now runs the source through `fitToIconGrid` before cutting slices:

- The artwork is measured by its **opaque bounds**, not by the canvas, so an icon already authored to Apple's template is passed through untouched, and one carrying part of the margin is scaled the rest of the way rather than twice over.
- Only sources that reach past the grid (plus a 2% tolerance) are re-composited; the scale/centre is done once at full canvas resolution with bicubic resampling, and every slice is cut from that.
- Sources too small to fill any slice we emit keep their single native slice unchanged — insetting artwork that small would leave nothing of it.
- Non-square, unreadable and fully transparent sources are left alone.
- The intermediate `icon-grid.png` matches the existing thumbnail cleanup pattern, so it is removed with the rest.

Measured on jDeploy's own default `icon.png` (512×512, full bleed): artwork now spans 409×412 of the 512 canvas ≈ 80.1%, against 512×512 (100%) before.

## Testing

`MacBundlerIconTest` gains three cases; all 237 shared-module tests pass.

- `insetsFullBleedArtworkOntoTheIconGrid` — fails on the pre-fix code (`expected: <824.0> but was: <1024.0>`), and also checks the artwork is centred.
- `leavesArtworkThatAlreadySitsOnTheGridAlone` — a 700-of-1024 source comes through at 700.
- `removesTheGridFittedSource` — no leftover intermediate.

## Delivery

The fix is in `shared`, so it reaches an installed `.app` through whichever component builds that bundle — the CLI at publish time for prebuilt platform bundles and for the local install paths, or `jdeploy-installer` when the installer builds the bundle on the end user's machine. The installer-built route tracks its own npm release rather than the CLI's: `jdeploy-installer@latest` is 6.1.5, whose `MacBundler` still has the pre-#475 single-slice `createThumbnails(File, File)`, so that route only picks this up once a release carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133NB1qceV5MzfvRzdVPxm5