### PR TITLE
chore: bump default jdeploy version in action to 6.1.7

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
   jdeploy_version:
     description: The version of Jdeploy
-    default: '6.1.1'
+    default: '6.1.7'
   jdeploy_registry_url:
     description: The URL of the jDeploy application registry
     required: false


### PR DESCRIPTION
Bumps the default `jdeploy_version` input in `action.yml` from `6.1.1` to `6.1.7` — the version just released (git tag `v6.1.7`, current HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)